### PR TITLE
Add function to get subtoken statistics

### DIFF
--- a/analysis/get_subtoken_statistics.py
+++ b/analysis/get_subtoken_statistics.py
@@ -1,0 +1,146 @@
+import argparse
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+import pandas as pd
+from datasets import Dataset, load_dataset
+from transformers import AutoTokenizer
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    # optional arguments
+    parser.add_argument(
+        "--tokenizer_name",
+        type=str,
+        default="oobabooga/llama-tokenizer",
+        help="Pointer to the HuggingFace repository to source the tokenizer.",
+    )
+    parser.add_argument(
+        "--dataset_name",
+        type=str,
+        default="ai2-adapt-dev/rm-benchmark-dev",
+        help="Pointer to the HuggingFace repository that contains the benchmark dataset.",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="filtered",
+        help="Dataset split to use for obtaining the subtoken statistics.",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=Path,
+        default=None,
+        help="Directory to save the results.",
+    )
+    parser.add_argument(
+        "--render_latex",
+        action="store_true",
+        help="If set, then it will render a LaTeX string instead of Markdown.",
+    )
+    args = parser.parse_args()
+    return args
+
+
+def get_dataset_tokens_per_subset(
+    tokenizer_name: str,
+    dataset_name: str,
+    split: str,
+) -> Dict[str, Dataset]:
+    """Get subtokens from a dataset
+
+    Expects that the dataset contains a 'prompt', 'chosen' and 'rejected'
+    columns. It will then assign the tokenized list in the 'prompt_tokens',
+    'chosen_tokens', and 'rejected_tokens', respectively.
+    """
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+    dataset = load_dataset(
+        dataset_name,
+        download_mode="force_redownload",
+        split=split,
+    )
+
+    subset_names = set(dataset["subset"])
+    subsets = {s: dataset.filter(lambda x: x["subset"] == s) for s in subset_names}
+
+    # Tokenize the text/s: some tokenizers like oobabooga adds a '1' padding
+    # when calling the tokenizer() function directly---that's why we're
+    # tokenizing it first to str, then calling convert_tokens_to_ids()
+    def _tokenize(example):
+        example["prompt_tokens"] = tokenizer.convert_tokens_to_ids(tokenizer.tokenize(example["prompt"]))
+        example["chosen_tokens"] = tokenizer.convert_tokens_to_ids(tokenizer.tokenize(example["chosen"]))
+        example["rejected_tokens"] = tokenizer.convert_tokens_to_ids(tokenizer.tokenize(example["rejected"]))
+        return example
+
+    return {s: d.map(_tokenize) for s, d in subsets.items()}
+
+
+def main():
+    args = get_args()
+    subsets = get_dataset_tokens_per_subset(
+        tokenizer_name=args.tokenizer_name,
+        dataset_name=args.dataset_name,
+        split=args.split,
+    )
+
+    # We will always include the prompt when computing the token lengths for the
+    # chosen and rejected responses
+    def _get_statistics(dataset: Dataset) -> Dict[str, Any]:
+        keys = ("chosen_lens", "rejected_lens", "chosen_unique_lens", "rejected_unique_lens")
+        stats = {k: [] for k in keys}
+        for eg in dataset:
+            prompt_tokens = eg.get("prompt_tokens")
+            chosen_tokens = eg.get("chosen_tokens")
+            rejected_tokens = eg.get("rejected_tokens")
+
+            stats["chosen_lens"].append(len(prompt_tokens) + len(chosen_tokens))
+            stats["rejected_lens"].append(len(prompt_tokens) + len(rejected_tokens))
+            # We compute the uniqueness across the whole instruction, NOT individually
+            stats["chosen_unique_lens"].append(len(set(prompt_tokens + chosen_tokens)))
+            stats["rejected_unique_lens"].append(len(set(prompt_tokens + rejected_tokens)))
+
+        return stats
+
+    subtoken_statistics = {name: _get_statistics(subset) for name, subset in subsets.items()}
+
+    # Create report table
+    df = pd.DataFrame(
+        [
+            {
+                "subset": name,
+                "chosen_avg": np.mean(stats["chosen_lens"]),
+                "chosen_max": np.max(stats["chosen_lens"]),
+                "chosen_min": np.min(stats["chosen_lens"]),
+                "chosen_unique_avg": np.mean(stats["chosen_unique_lens"]),
+                "chosen_unique_max": np.max(stats["chosen_unique_lens"]),
+                "chosen_unique_min": np.min(stats["chosen_unique_lens"]),
+                "rejected_avg": np.mean(stats["rejected_lens"]),
+                "rejected_max": np.max(stats["rejected_lens"]),
+                "rejected_min": np.min(stats["rejected_lens"]),
+                "rejected_unique_avg": np.mean(stats["rejected_unique_lens"]),
+                "rejected_unique_max": np.max(stats["rejected_unique_lens"]),
+                "rejected_unique_min": np.min(stats["rejected_unique_lens"]),
+            }
+            for name, stats in subtoken_statistics.items()
+        ]
+    )
+
+    render_string = (
+        df.round(4).astype(str).to_latex(index=False)
+        if args.render_latex
+        else df.to_markdown(index=False, tablefmt="github")
+    )
+    render_string = render_string.replace("NaN", "")
+    render_string = render_string.replace("nan", "")
+    print(render_string)
+
+    if args.output_dir:
+        print(f"Saving results to '{args.output_dir}' directory")
+        Path(args.output_dir).mkdir(exist_ok=True, parents=True)
+        df.to_csv(args.output_dir / "subtoken_statistics.csv", index=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implementation is based on [this notebook](https://huggingface.co/datasets/ai2-adapt-dev/rm-benchmark-dev/blob/main/explore_datasets.ipynb). The only difference is that when computing for the unique subtoken lengths, I combined the prompt and chosen/rejected token IDs first before getting the unique IDs. I think it's more faithful to how a model "sees" the prompt.


```
| subset                |   chosen_avg |   chosen_max |   chosen_min |   chosen_unique_avg |   chosen_unique_max |   chosen_unique_min |   rejected_avg |   rejected_max |   rejected_min |   rejected_unique_avg |   rejected_unique_max |   rejected_unique_min |
|-----------------------|--------------|--------------|--------------|---------------------|---------------------|---------------------|----------------|----------------|----------------|-----------------------|-----------------------|-----------------------|
| donotanswer           |     169.61   |          745 |           20 |            103.743  |                 358 |                  18 |        320.5   |            735 |             20 |              156.941  |                   337 |                    13 |
| mt-bench-med          |     376.675  |          867 |          145 |            162.05   |                 281 |                  76 |        410.275 |           1251 |             63 |              145.425  |                   495 |                    40 |
| llmbar-adver-manual   |     159.804  |          607 |           23 |             91.9565 |                 273 |                  18 |        264.37  |            737 |             33 |              140.13   |                   385 |                    24 |
| llmbar-adver-neighbor |      70.2239 |          603 |            9 |             43.3134 |                 250 |                   8 |        172.507 |            865 |             13 |               90.9328 |                   324 |                     9 |
| mt-bench-hard         |     284.432  |          533 |           79 |            131.405  |                 257 |                  49 |        348.676 |           1254 |             62 |              136.162  |                   309 |                    48 |
| xstest-should-refuse  |     129.227  |          402 |           18 |             80.5519 |                 194 |                  16 |        217.019 |            549 |             15 |              116.149  |                   245 |                    13 |
| llmbar-natural        |     139.42   |          907 |           17 |             74.99   |                 354 |                  14 |        129.82  |            900 |             18 |               70.07   |                   352 |                    14 |
| alpacaeval-length     |     510.589  |         1604 |           55 |            192.442  |                 434 |                  30 |        596.895 |           2242 |             52 |              188.547  |                   664 |                    38 |
| xstest-should-respond |     188.708  |          515 |           20 |            103.788  |                 231 |                  15 |        107.356 |            465 |             16 |               67.328  |                   202 |                    16 |
| hep-cpp               |     261.262  |          833 |           53 |             99.8537 |                 201 |                  37 |        259.488 |            835 |             57 |               99.372  |                   201 |                    40 |
| alpacaeval-hard       |     411.684  |         1112 |           57 |            172.537  |                 359 |                  45 |        136.926 |            711 |             12 |               70.9684 |                   297 |                     8 |
| hep-go                |     266.22   |          732 |           55 |             99.622  |                 201 |                  36 |        264.598 |            720 |             57 |               99.189  |                   201 |                    37 |
| llmbar-adver-GPTOut   |      96.4255 |          393 |           18 |             60.0426 |                 241 |                  13 |        101     |            476 |             20 |               55.0426 |                   228 |                    14 |
| llmbar-adver-GPTInst  |     170.109  |          636 |           15 |             92.9457 |                 287 |                  12 |        377.359 |            959 |             15 |              179.37   |                   471 |                    13 |
| refusals-dangerous    |     131.22   |          175 |           68 |             90.19   |                 117 |                  52 |        458.61  |            804 |            103 |              211      |                   365 |                    55 |
| alpacaeval-easy       |     591.26   |         1332 |           40 |            252.91   |                 630 |                  33 |        167.33  |           1043 |             15 |               83.44   |                   290 |                    12 |
| mt-bench-easy         |     377.143  |          778 |          171 |            165.893  |                 279 |                  78 |        551.143 |           1740 |             31 |              116.179  |                   260 |                    19 |
| hep-java              |     263.14   |          748 |           55 |            102.311  |                 207 |                  39 |        260.939 |            733 |             54 |              101.927  |                   206 |                    41 |
| hep-python            |     211.988  |          624 |           53 |             85.6463 |                 190 |                  36 |        211.146 |            612 |             49 |               85.3049 |                   190 |                    35 |
| hep-js                |     251.165  |          771 |           53 |             93.2744 |                 192 |                  37 |        249.695 |            774 |             52 |               92.9268 |                   192 |                    40 |
| refusals-offensive    |      82.28   |          142 |           24 |             63.89   |                 109 |                  22 |        298.63  |           1117 |             26 |              134.02   |                   477 |                    19 |
| hep-rust              |     221.256  |          988 |           46 |             95.1402 |                 192 |                  36 |        219.049 | 
```