### PR TITLE
Fix EOS token bug on FastChat models (non DPO)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # To get the latest id, run `beaker image pull ai2/cuda11.8-cudnn8-dev-ubuntu20.04` 
 # and then `docker image list`, to verify docker image is pulled
 # e.g. `Image is up to date for gcr.io/ai2-beaker-core/public/cncl3kcetc4q9nvqumrg:latest`
-FROM gcr.io/ai2-beaker-core/public/cntl21gr2bs3fhh2sdh0:latest
+FROM gcr.io/ai2-beaker-core/public/co2v4u6a1d7h4i0mf5v0:latest
 
 RUN apt update && apt install -y openjdk-8-jre-headless
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Notes: Do not use the character - in image names for beaker,
 When updating the `Dockerfile`, make sure to see the instructions at the top to update the base cuda version. 
 
 In development, we have the following docker images (most recent first as it's likely what you need).
+- `nathanl/rewardbench_v3`: fix EOS token bug on FastChat models (GH #90)
 - `nathanl/rewardbench_v2`: fix beaver cost model
 - `nathanl/rewardbench_v1`: release version
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Notes: Do not use the character - in image names for beaker,
 When updating the `Dockerfile`, make sure to see the instructions at the top to update the base cuda version. 
 
 In development, we have the following docker images (most recent first as it's likely what you need).
-- `nathanl/rewardbench_v3`: fix EOS token bug on FastChat models (GH #90)
+- `nathanl/rewardbench_v4`: fix EOS token bug on FastChat models (GH #90)
 - `nathanl/rewardbench_v2`: fix beaver cost model
 - `nathanl/rewardbench_v1`: release version
 

--- a/rewardbench/__init__.py
+++ b/rewardbench/__init__.py
@@ -17,6 +17,7 @@ from .chattemplates import *  # noqa
 from .dpo import DPOInference
 from .models import DPO_MODEL_CONFIG, REWARD_MODEL_CONFIG
 from .utils import (
+    check_tokenizer_chat_template,
     load_bon_dataset,
     load_eval_dataset,
     prepare_dialogue,
@@ -25,6 +26,7 @@ from .utils import (
 )
 
 __all__ = [
+    check_tokenizer_chat_template,
     DPOInference,
     DPO_MODEL_CONFIG,
     load_bon_dataset,

--- a/rewardbench/utils.py
+++ b/rewardbench/utils.py
@@ -36,6 +36,16 @@ HF_TOKEN = os.getenv("HF_TOKEN", None)
 api = HfApi(token=HF_TOKEN)
 
 
+def check_tokenizer_chat_template(tokenizer):
+    """
+    Check if tokenizer has chat_template attribute.
+    """
+    if hasattr(tokenizer, "chat_template"):
+        if tokenizer.chat_template is not None:
+            return True
+    return False
+
+
 def save_to_hub(
     results_dict: Union[Dict, List],
     model_name: str,
@@ -139,10 +149,7 @@ def load_eval_dataset(
 
     # Apply chat template
     if not custom_dialogue_formatting:
-        usable_tokenizer = False
-        if hasattr(tokenizer, "chat_template"):
-            if tokenizer.chat_template is not None:
-                usable_tokenizer = True
+        usable_tokenizer = check_tokenizer_chat_template(tokenizer)
 
         # assert either conv is passed or tokenizer has chat_template
         assert conv is not None or usable_tokenizer
@@ -278,10 +285,7 @@ def load_bon_dataset(
 
     # Apply chat template
     if not custom_dialogue_formatting:
-        usable_tokenizer = False
-        if hasattr(tokenizer, "chat_template"):
-            if tokenizer.chat_template is not None:
-                usable_tokenizer = True
+        usable_tokenizer = check_tokenizer_chat_template(tokenizer)
 
         # assert either conv is passed or tokenizer has chat_template
         assert conv is not None or usable_tokenizer

--- a/rewardbench/utils.py
+++ b/rewardbench/utils.py
@@ -38,7 +38,7 @@ api = HfApi(token=HF_TOKEN)
 
 def check_tokenizer_chat_template(tokenizer):
     """
-    Check if tokenizer has chat_template attribute.
+    Check if tokenizer has non none chat_template attribute.
     """
     if hasattr(tokenizer, "chat_template"):
         if tokenizer.chat_template is not None:

--- a/scripts/configs/eval_configs.yaml
+++ b/scripts/configs/eval_configs.yaml
@@ -34,13 +34,13 @@ weqweasdas/hh_rlhf_rm_open_llama_3b:
   batch_size: 64
   trust_remote_code: False
   dpo: False
-llm-blender/PairRM-hf:
-  model: 'llm-blender/PairRM-hf'
-  tokenizer: 'llm-blender/PairRM-hf'
-  chat_template: 'tulu'
-  batch_size: 64
-  trust_remote_code: False
-  dpo: False
+# llm-blender/PairRM-hf:
+#   model: 'llm-blender/PairRM-hf'
+#   tokenizer: 'llm-blender/PairRM-hf'
+#   chat_template: 'tulu'
+#   batch_size: 64
+#   trust_remote_code: False
+#   dpo: False
 berkeley-nest/Starling-RM-7B-alpha:
   model: 'berkeley-nest/Starling-RM-7B-alpha'
   tokenizer: 'meta-llama/Llama-2-7b-chat-hf'
@@ -48,20 +48,20 @@ berkeley-nest/Starling-RM-7B-alpha:
   batch_size: 16
   trust_remote_code: False
   dpo: False
-stanfordnlp/SteamSHP-flan-t5-xl:
-  model: 'stanfordnlp/SteamSHP-flan-t5-xl'
-  tokenizer: 'stanfordnlp/SteamSHP-flan-t5-xl'
-  chat_template: 'tulu'
-  batch_size: 32
-  trust_remote_code: False
-  dpo: False
-stanfordnlp/SteamSHP-flan-t5-large:
-  model: 'stanfordnlp/SteamSHP-flan-t5-large'
-  tokenizer: 'stanfordnlp/SteamSHP-flan-t5-large'
-  chat_template: 'tulu'
-  batch_size: 32
-  trust_remote_code: False
-  dpo: False
+# stanfordnlp/SteamSHP-flan-t5-xl:
+#   model: 'stanfordnlp/SteamSHP-flan-t5-xl'
+#   tokenizer: 'stanfordnlp/SteamSHP-flan-t5-xl'
+#   chat_template: 'tulu'
+#   batch_size: 32
+#   trust_remote_code: False
+#   dpo: False
+# stanfordnlp/SteamSHP-flan-t5-large:
+#   model: 'stanfordnlp/SteamSHP-flan-t5-large'
+#   tokenizer: 'stanfordnlp/SteamSHP-flan-t5-large'
+#   chat_template: 'tulu'
+#   batch_size: 32
+#   trust_remote_code: False
+#   dpo: False
 PKU-Alignment/beaver-7b-v1.0-reward:
   model: 'PKU-Alignment/beaver-7b-v1.0-reward'
   tokenizer: 'PKU-Alignment/beaver-7b-v1.0-reward'
@@ -83,321 +83,321 @@ IDEA-CCNL/Ziya-LLaMA-7B-Reward:
   batch_size: 16
   trust_remote_code: True
   dpo: False
-Nexusflow/Starling-RM-34B:
-  model: 'Nexusflow/Starling-RM-34B'
-  tokenizer: '01-ai/Yi-34B-Chat'
-  chat_template: 'Yi-34b-chat'
-  num_gpus: 2
-  batch_size: 2
-  trust_remote_code: False
-  dpo: False
-stabilityai/stablelm-zephyr-3b:
-  ref_model: stabilityai/stablelm-3b-4e1t
-  tokenizer: stabilityai/stablelm-zephyr-3b
-  chat_template:
-  batch_size: 12
-  trust_remote_code: False
-  dpo: True
-stabilityai/stablelm-2-zephyr-1_6b:
-  ref_model: stabilityai/stablelm-2-1_6b
-  tokenizer: stabilityai/stablelm-2-zephyr-1_6b
-  chat_template:
-  batch_size: 6
-  trust_remote_code: True
-  dpo: True
-HuggingFaceH4/zephyr-7b-beta:
-  ref_model: HuggingFaceH4/mistral-7b-sft-beta
-  tokenizer: HuggingFaceH4/zephyr-7b-beta
-  chat_template:
-  batch_size: 4
-  trust_remote_code: False
-  dpo: True
-HuggingFaceH4/zephyr-7b-alpha:
-  ref_model: HuggingFaceH4/mistral-7b-sft-alpha
-  tokenizer: HuggingFaceH4/zephyr-7b-alpha
-  chat_template:
-  batch_size: 4
-  trust_remote_code: False
-  dpo: True
-Qwen/Qwen1.5-0.5B-Chat:
-  ref_model: Qwen/Qwen1.5-0.5B
-  tokenizer: Qwen/Qwen1.5-0.5B-Chat
-  chat_template:
-  batch_size: 6
-  trust_remote_code: False
-  dpo: True
-Qwen/Qwen1.5-1.8B-Chat:
-  ref_model: Qwen/Qwen1.5-1.8B
-  tokenizer: Qwen/Qwen1.5-1.8B-Chat
-  chat_template:
-  batch_size: 3
-  trust_remote_code: False
-  dpo: True
-Qwen/Qwen1.5-4B-Chat:
-  ref_model: Qwen/Qwen1.5-4B
-  tokenizer: Qwen/Qwen1.5-4B-Chat
-  chat_template:
-  batch_size: 2
-  trust_remote_code: False
-  dpo: True
-Qwen/Qwen1.5-7B-Chat:
-  ref_model: Qwen/Qwen1.5-7B
-  tokenizer: Qwen/Qwen1.5-7B-Chat
-  chat_template:
-  batch_size: 2
-  trust_remote_code: False
-  dpo: True
-Qwen/Qwen1.5-14B-Chat:
-  ref_model: Qwen/Qwen1.5-14B
-  tokenizer: Qwen/Qwen1.5-14B-Chat
-  chat_template:
-  batch_size: 2
-  num_gpus: 2
-  trust_remote_code: False
-  dpo: True
-Qwen/Qwen1.5-72B-Chat:
-  ref_model: Qwen/Qwen1.5-72B
-  tokenizer: Qwen/Qwen1.5-72B-Chat
-  chat_template:
-  batch_size: 1
-  num_gpus: 4
-  trust_remote_code: False
-  dpo: True
-mistralai/Mixtral-8x7B-Instruct-v0.1:
-  ref_model: mistralai/Mixtral-8x7B-v0.1
-  tokenizer: mistralai/Mixtral-8x7B-Instruct-v0.1
-  chat_template:
-  batch_size: 1
-  num_gpus: 4
-  trust_remote_code: False
-  dpo: True
-NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO:
-  ref_model: NousResearch/Nous-Hermes-2-Mixtral-8x7B-SFT
-  tokenizer: NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO
-  chat_template:
-  batch_size: 1
-  num_gpus: 4
-  trust_remote_code: True
-  dpo: True
-NousResearch/Nous-Hermes-2-Mistral-7B-DPO:
-  ref_model: teknium/OpenHermes-2.5-Mistral-7B
-  tokenizer: NousResearch/Nous-Hermes-2-Mistral-7B-DPO
-  chat_template:
-  batch_size: 4
-  trust_remote_code: False
-  dpo: True
-HuggingFaceH4/zephyr-7b-gemma-v0.1:
-  ref_model: HuggingFaceH4/zephyr-7b-gemma-sft-v0.1
-  tokenizer: HuggingFaceH4/zephyr-7b-gemma-v0.1
-  chat_template:
-  batch_size: 2
-  trust_remote_code: False
-  dpo: True
-allenai/tulu-2-dpo-70b:
-  ref_model: allenai/tulu-2-70b
-  tokenizer: allenai/tulu-2-dpo-70b
-  chat_template: tulu
-  num_gpus: 4
-  batch_size: 2
-  trust_remote_code: False
-  dpo: True
-allenai/tulu-2-dpo-13b:
-  ref_model: allenai/tulu-2-13b
-  tokenizer: allenai/tulu-2-dpo-13b
-  chat_template: tulu
-  num_gpus: 2
-  batch_size: 2
-  trust_remote_code: False
-  dpo: True
-allenai/tulu-2-dpo-7b:
-  ref_model: allenai/tulu-2-7b
-  tokenizer: allenai/tulu-2-dpo-7b
-  chat_template: tulu
-  batch_size: 2
-  trust_remote_code: False
-  dpo: True
-allenai/OLMo-7B-Instruct:
-  ref_model: allenai/OLMo-7B-SFT
-  tokenizer: allenai/OLMo-7B-Instruct
-  chat_template:
-  batch_size: 2
-  trust_remote_code: True
-  dpo: True
-# Added March 21st 2024
-weqweasdas/RM-Gemma-2B:
-  model: weqweasdas/RM-Gemma-2B
-  tokenizer: weqweasdas/RM-Gemma-2B
-  chat_template: # empty for tokenizer
-  batch_size: 16
-  trust_remote_code: False
-  dpo: False
-weqweasdas/RM-Gemma-7B:
-  model: weqweasdas/RM-Gemma-7B
-  tokenizer: weqweasdas/RM-Gemma-7B
-  chat_template: # empty for tokenizer
-  batch_size: 16
-  trust_remote_code: False
-  dpo: False
-weqweasdas/RM-Gemma-7B-4096:
-  model: weqweasdas/RM-Gemma-7B-4096
-  tokenizer: weqweasdas/RM-Gemma-7B-4096
-  chat_template: # empty for tokenizer
-  batch_size: 16
-  trust_remote_code: False
-  dpo: False
-Ray2333/reward-model-Mistral-7B-instruct-Unified-Feedback:
-  model: Ray2333/reward-model-Mistral-7B-instruct-Unified-Feedback
-  tokenizer: Ray2333/reward-model-Mistral-7B-instruct-Unified-Feedback
-  chat_template: # empty for tokenizer
-  batch_size: 16
-  trust_remote_code: False
-  dpo: False
-hendrydong/Mistral-RM-for-RAFT-GSHF-v0:
-  model: hendrydong/Mistral-RM-for-RAFT-GSHF-v0
-  tokenizer: hendrydong/Mistral-RM-for-RAFT-GSHF-v0
-  chat_template: # empty for tokenizer
-  batch_size: 16
-  trust_remote_code: False
-  dpo: False
-weqweasdas/RM-Mistral-7B:
-  model: weqweasdas/RM-Mistral-7B
-  tokenizer: weqweasdas/RM-Mistral-7B
-  chat_template: # empty for tokenizer
-  batch_size: 16
-  trust_remote_code: False
-  dpo: False
-# Added March 25th 2024 KTO / Archangel models follow
-ContextualAI/archangel_sft-kto_llama7b:
-  model: ContextualAI/archangel_sft-kto_llama7b
-  ref_model: ContextualAI/archangel_sft_llama7b
-  tokenizer: ContextualAI/archangel_sft-kto_llama7b
-  chat_template: tulu
-  batch_size: 4
-  trust_remote_code: False
-  dpo: True
-ContextualAI/archangel_sft-dpo_llama7b:
-  model: ContextualAI/archangel_sft-dpo_llama7b
-  ref_model: ContextualAI/archangel_sft_llama7b
-  tokenizer: ContextualAI/archangel_sft-dpo_llama7b
-  chat_template: tulu
-  batch_size: 4
-  trust_remote_code: False
-  dpo: True
-ContextualAI/archangel_sft-kto_llama13b:
-  model: ContextualAI/archangel_sft-kto_llama13b
-  ref_model: ContextualAI/archangel_sft_llama13b
-  tokenizer: ContextualAI/archangel_sft-kto_llama13b
-  chat_template: tulu
-  batch_size: 2
-  num_gpus: 2
-  trust_remote_code: False
-  dpo: True
-ContextualAI/archangel_sft-dpo_llama13b:
-  model: ContextualAI/archangel_sft-dpo_llama13b
-  ref_model: ContextualAI/archangel_sft_llama13b
-  tokenizer: ContextualAI/archangel_sft-dpo_llama13b
-  chat_template: tulu
-  batch_size: 2
-  num_gpus: 2
-  trust_remote_code: False
-  dpo: True
-ContextualAI/archangel_sft-kto_llama30b:
-  model: ContextualAI/archangel_sft-kto_llama30b
-  ref_model: ContextualAI/archangel_sft_llama30b
-  tokenizer: ContextualAI/archangel_sft-kto_llama30b
-  chat_template: tulu
-  batch_size: 1
-  num_gpus: 4
-  trust_remote_code: False
-  dpo: True
-ContextualAI/archangel_sft-dpo_llama30b:
-  model: ContextualAI/archangel_sft-dpo_llama30b
-  ref_model: ContextualAI/archangel_sft_llama30b
-  tokenizer: ContextualAI/archangel_sft-dpo_llama30b
-  chat_template: tulu
-  batch_size: 1
-  num_gpus: 4
-  trust_remote_code: False
-  dpo: True
-ContextualAI/archangel_sft-dpo_pythia1-4b:
-  model: ContextualAI/archangel_sft-dpo_pythia1-4b
-  ref_model: ContextualAI/archangel_sft_pythia1-4b
-  tokenizer: ContextualAI/archangel_sft-dpo_pythia1-4b
-  chat_template: tulu
-  batch_size: 6
-  trust_remote_code: False
-  dpo: True
-ContextualAI/archangel_sft-kto_pythia1-4b:
-  model: ContextualAI/archangel_sft-kto_pythia1-4b
-  ref_model: ContextualAI/archangel_sft_pythia1-4b
-  tokenizer: ContextualAI/archangel_sft-kto_pythia1-4b
-  chat_template: tulu
-  batch_size: 6
-  trust_remote_code: False
-  dpo: True
-ContextualAI/archangel_sft-dpo_pythia2-8b:
-  model: ContextualAI/archangel_sft-dpo_pythia2-8b
-  ref_model: ContextualAI/archangel_sft_pythia2-8b
-  tokenizer: ContextualAI/archangel_sft-dpo_pythia2-8b
-  chat_template: tulu
-  batch_size: 4
-  trust_remote_code: False
-  dpo: True
-ContextualAI/archangel_sft-kto_pythia2-8b:
-  model: ContextualAI/archangel_sft-kto_pythia2-8b
-  ref_model: ContextualAI/archangel_sft_pythia2-8b
-  tokenizer: ContextualAI/archangel_sft-kto_pythia2-8b
-  chat_template: tulu
-  batch_size: 4
-  trust_remote_code: False
-  dpo: True
-ContextualAI/archangel_sft-dpo_pythia6-9b:
-  model: ContextualAI/archangel_sft-dpo_pythia6-9b
-  ref_model: ContextualAI/archangel_sft_pythia6-9b
-  tokenizer: ContextualAI/archangel_sft-dpo_pythia6-9b
-  chat_template: tulu
-  batch_size: 4
-  trust_remote_code: False
-  dpo: True
-ContextualAI/archangel_sft-kto_pythia6-9b:
-  model: ContextualAI/archangel_sft-kto_pythia6-9b
-  ref_model: ContextualAI/archangel_sft_pythia6-9b
-  tokenizer: ContextualAI/archangel_sft-kto_pythia6-9b
-  chat_template: tulu
-  batch_size: 4
-  trust_remote_code: False
-  dpo: True
-ContextualAI/archangel_sft-dpo_pythia12-0b:
-  model: ContextualAI/archangel_sft-dpo_pythia12-0b
-  ref_model: ContextualAI/archangel_sft_pythia12-0b
-  tokenizer: ContextualAI/archangel_sft-dpo_pythia12-0b
-  chat_template: tulu
-  batch_size: 4
-  num_gpus: 2
-  trust_remote_code: False
-  dpo: True
-ContextualAI/archangel_sft-kto_pythia12-0b:
-  model: ContextualAI/archangel_sft-kto_pythia12-0b
-  ref_model: ContextualAI/archangel_sft_pythia12-0b
-  tokenizer: ContextualAI/archangel_sft-kto_pythia12-0b
-  chat_template: tulu
-  batch_size: 4
-  num_gpus: 2
-  trust_remote_code: False
-  dpo: True
-0-hero/Matter-0.1-7B-DPO-preview:
-  model: 0-hero/Matter-0.1-7B-DPO-preview
-  ref_model: 0-hero/Matter-0.1-7B
-  tokenizer: 0-hero/Matter-0.1-7B-DPO-preview
-  chat_template: # none for tokenizer
-  batch_size: 4
-  trust_remote_code: False
-  dpo: True
-0-hero/Matter-0.1-7B-boost-DPO-preview:
-  model: 0-hero/Matter-0.1-7B-boost-DPO-preview
-  ref_model: 0-hero/Matter-0.1-7B-boost
-  tokenizer: 0-hero/Matter-0.1-7B-boost-DPO-preview
-  chat_template: # none for tokenizer
-  batch_size: 4
-  trust_remote_code: False
-  dpo: True
+# Nexusflow/Starling-RM-34B:
+#   model: 'Nexusflow/Starling-RM-34B'
+#   tokenizer: '01-ai/Yi-34B-Chat'
+#   chat_template: 'Yi-34b-chat'
+#   num_gpus: 2
+#   batch_size: 2
+#   trust_remote_code: False
+#   dpo: False
+# stabilityai/stablelm-zephyr-3b:
+#   ref_model: stabilityai/stablelm-3b-4e1t
+#   tokenizer: stabilityai/stablelm-zephyr-3b
+#   chat_template:
+#   batch_size: 12
+#   trust_remote_code: False
+#   dpo: True
+# stabilityai/stablelm-2-zephyr-1_6b:
+#   ref_model: stabilityai/stablelm-2-1_6b
+#   tokenizer: stabilityai/stablelm-2-zephyr-1_6b
+#   chat_template:
+#   batch_size: 6
+#   trust_remote_code: True
+#   dpo: True
+# HuggingFaceH4/zephyr-7b-beta:
+#   ref_model: HuggingFaceH4/mistral-7b-sft-beta
+#   tokenizer: HuggingFaceH4/zephyr-7b-beta
+#   chat_template:
+#   batch_size: 4
+#   trust_remote_code: False
+#   dpo: True
+# HuggingFaceH4/zephyr-7b-alpha:
+#   ref_model: HuggingFaceH4/mistral-7b-sft-alpha
+#   tokenizer: HuggingFaceH4/zephyr-7b-alpha
+#   chat_template:
+#   batch_size: 4
+#   trust_remote_code: False
+#   dpo: True
+# Qwen/Qwen1.5-0.5B-Chat:
+#   ref_model: Qwen/Qwen1.5-0.5B
+#   tokenizer: Qwen/Qwen1.5-0.5B-Chat
+#   chat_template:
+#   batch_size: 6
+#   trust_remote_code: False
+#   dpo: True
+# Qwen/Qwen1.5-1.8B-Chat:
+#   ref_model: Qwen/Qwen1.5-1.8B
+#   tokenizer: Qwen/Qwen1.5-1.8B-Chat
+#   chat_template:
+#   batch_size: 3
+#   trust_remote_code: False
+#   dpo: True
+# Qwen/Qwen1.5-4B-Chat:
+#   ref_model: Qwen/Qwen1.5-4B
+#   tokenizer: Qwen/Qwen1.5-4B-Chat
+#   chat_template:
+#   batch_size: 2
+#   trust_remote_code: False
+#   dpo: True
+# Qwen/Qwen1.5-7B-Chat:
+#   ref_model: Qwen/Qwen1.5-7B
+#   tokenizer: Qwen/Qwen1.5-7B-Chat
+#   chat_template:
+#   batch_size: 2
+#   trust_remote_code: False
+#   dpo: True
+# Qwen/Qwen1.5-14B-Chat:
+#   ref_model: Qwen/Qwen1.5-14B
+#   tokenizer: Qwen/Qwen1.5-14B-Chat
+#   chat_template:
+#   batch_size: 2
+#   num_gpus: 2
+#   trust_remote_code: False
+#   dpo: True
+# Qwen/Qwen1.5-72B-Chat:
+#   ref_model: Qwen/Qwen1.5-72B
+#   tokenizer: Qwen/Qwen1.5-72B-Chat
+#   chat_template:
+#   batch_size: 1
+#   num_gpus: 4
+#   trust_remote_code: False
+#   dpo: True
+# mistralai/Mixtral-8x7B-Instruct-v0.1:
+#   ref_model: mistralai/Mixtral-8x7B-v0.1
+#   tokenizer: mistralai/Mixtral-8x7B-Instruct-v0.1
+#   chat_template:
+#   batch_size: 1
+#   num_gpus: 4
+#   trust_remote_code: False
+#   dpo: True
+# NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO:
+#   ref_model: NousResearch/Nous-Hermes-2-Mixtral-8x7B-SFT
+#   tokenizer: NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO
+#   chat_template:
+#   batch_size: 1
+#   num_gpus: 4
+#   trust_remote_code: True
+#   dpo: True
+# NousResearch/Nous-Hermes-2-Mistral-7B-DPO:
+#   ref_model: teknium/OpenHermes-2.5-Mistral-7B
+#   tokenizer: NousResearch/Nous-Hermes-2-Mistral-7B-DPO
+#   chat_template:
+#   batch_size: 4
+#   trust_remote_code: False
+#   dpo: True
+# HuggingFaceH4/zephyr-7b-gemma-v0.1:
+#   ref_model: HuggingFaceH4/zephyr-7b-gemma-sft-v0.1
+#   tokenizer: HuggingFaceH4/zephyr-7b-gemma-v0.1
+#   chat_template:
+#   batch_size: 2
+#   trust_remote_code: False
+#   dpo: True
+# allenai/tulu-2-dpo-70b:
+#   ref_model: allenai/tulu-2-70b
+#   tokenizer: allenai/tulu-2-dpo-70b
+#   chat_template: tulu
+#   num_gpus: 4
+#   batch_size: 2
+#   trust_remote_code: False
+#   dpo: True
+# allenai/tulu-2-dpo-13b:
+#   ref_model: allenai/tulu-2-13b
+#   tokenizer: allenai/tulu-2-dpo-13b
+#   chat_template: tulu
+#   num_gpus: 2
+#   batch_size: 2
+#   trust_remote_code: False
+#   dpo: True
+# allenai/tulu-2-dpo-7b:
+#   ref_model: allenai/tulu-2-7b
+#   tokenizer: allenai/tulu-2-dpo-7b
+#   chat_template: tulu
+#   batch_size: 2
+#   trust_remote_code: False
+#   dpo: True
+# allenai/OLMo-7B-Instruct:
+#   ref_model: allenai/OLMo-7B-SFT
+#   tokenizer: allenai/OLMo-7B-Instruct
+#   chat_template:
+#   batch_size: 2
+#   trust_remote_code: True
+#   dpo: True
+# # Added March 21st 2024
+# weqweasdas/RM-Gemma-2B:
+#   model: weqweasdas/RM-Gemma-2B
+#   tokenizer: weqweasdas/RM-Gemma-2B
+#   chat_template: # empty for tokenizer
+#   batch_size: 16
+#   trust_remote_code: False
+#   dpo: False
+# weqweasdas/RM-Gemma-7B:
+#   model: weqweasdas/RM-Gemma-7B
+#   tokenizer: weqweasdas/RM-Gemma-7B
+#   chat_template: # empty for tokenizer
+#   batch_size: 16
+#   trust_remote_code: False
+#   dpo: False
+# weqweasdas/RM-Gemma-7B-4096:
+#   model: weqweasdas/RM-Gemma-7B-4096
+#   tokenizer: weqweasdas/RM-Gemma-7B-4096
+#   chat_template: # empty for tokenizer
+#   batch_size: 16
+#   trust_remote_code: False
+#   dpo: False
+# Ray2333/reward-model-Mistral-7B-instruct-Unified-Feedback:
+#   model: Ray2333/reward-model-Mistral-7B-instruct-Unified-Feedback
+#   tokenizer: Ray2333/reward-model-Mistral-7B-instruct-Unified-Feedback
+#   chat_template: # empty for tokenizer
+#   batch_size: 16
+#   trust_remote_code: False
+#   dpo: False
+# hendrydong/Mistral-RM-for-RAFT-GSHF-v0:
+#   model: hendrydong/Mistral-RM-for-RAFT-GSHF-v0
+#   tokenizer: hendrydong/Mistral-RM-for-RAFT-GSHF-v0
+#   chat_template: # empty for tokenizer
+#   batch_size: 16
+#   trust_remote_code: False
+#   dpo: False
+# weqweasdas/RM-Mistral-7B:
+#   model: weqweasdas/RM-Mistral-7B
+#   tokenizer: weqweasdas/RM-Mistral-7B
+#   chat_template: # empty for tokenizer
+#   batch_size: 16
+#   trust_remote_code: False
+#   dpo: False
+# # Added March 25th 2024 KTO / Archangel models follow
+# ContextualAI/archangel_sft-kto_llama7b:
+#   model: ContextualAI/archangel_sft-kto_llama7b
+#   ref_model: ContextualAI/archangel_sft_llama7b
+#   tokenizer: ContextualAI/archangel_sft-kto_llama7b
+#   chat_template: tulu
+#   batch_size: 4
+#   trust_remote_code: False
+#   dpo: True
+# ContextualAI/archangel_sft-dpo_llama7b:
+#   model: ContextualAI/archangel_sft-dpo_llama7b
+#   ref_model: ContextualAI/archangel_sft_llama7b
+#   tokenizer: ContextualAI/archangel_sft-dpo_llama7b
+#   chat_template: tulu
+#   batch_size: 4
+#   trust_remote_code: False
+#   dpo: True
+# ContextualAI/archangel_sft-kto_llama13b:
+#   model: ContextualAI/archangel_sft-kto_llama13b
+#   ref_model: ContextualAI/archangel_sft_llama13b
+#   tokenizer: ContextualAI/archangel_sft-kto_llama13b
+#   chat_template: tulu
+#   batch_size: 2
+#   num_gpus: 2
+#   trust_remote_code: False
+#   dpo: True
+# ContextualAI/archangel_sft-dpo_llama13b:
+#   model: ContextualAI/archangel_sft-dpo_llama13b
+#   ref_model: ContextualAI/archangel_sft_llama13b
+#   tokenizer: ContextualAI/archangel_sft-dpo_llama13b
+#   chat_template: tulu
+#   batch_size: 2
+#   num_gpus: 2
+#   trust_remote_code: False
+#   dpo: True
+# ContextualAI/archangel_sft-kto_llama30b:
+#   model: ContextualAI/archangel_sft-kto_llama30b
+#   ref_model: ContextualAI/archangel_sft_llama30b
+#   tokenizer: ContextualAI/archangel_sft-kto_llama30b
+#   chat_template: tulu
+#   batch_size: 1
+#   num_gpus: 4
+#   trust_remote_code: False
+#   dpo: True
+# ContextualAI/archangel_sft-dpo_llama30b:
+#   model: ContextualAI/archangel_sft-dpo_llama30b
+#   ref_model: ContextualAI/archangel_sft_llama30b
+#   tokenizer: ContextualAI/archangel_sft-dpo_llama30b
+#   chat_template: tulu
+#   batch_size: 1
+#   num_gpus: 4
+#   trust_remote_code: False
+#   dpo: True
+# ContextualAI/archangel_sft-dpo_pythia1-4b:
+#   model: ContextualAI/archangel_sft-dpo_pythia1-4b
+#   ref_model: ContextualAI/archangel_sft_pythia1-4b
+#   tokenizer: ContextualAI/archangel_sft-dpo_pythia1-4b
+#   chat_template: tulu
+#   batch_size: 6
+#   trust_remote_code: False
+#   dpo: True
+# ContextualAI/archangel_sft-kto_pythia1-4b:
+#   model: ContextualAI/archangel_sft-kto_pythia1-4b
+#   ref_model: ContextualAI/archangel_sft_pythia1-4b
+#   tokenizer: ContextualAI/archangel_sft-kto_pythia1-4b
+#   chat_template: tulu
+#   batch_size: 6
+#   trust_remote_code: False
+#   dpo: True
+# ContextualAI/archangel_sft-dpo_pythia2-8b:
+#   model: ContextualAI/archangel_sft-dpo_pythia2-8b
+#   ref_model: ContextualAI/archangel_sft_pythia2-8b
+#   tokenizer: ContextualAI/archangel_sft-dpo_pythia2-8b
+#   chat_template: tulu
+#   batch_size: 4
+#   trust_remote_code: False
+#   dpo: True
+# ContextualAI/archangel_sft-kto_pythia2-8b:
+#   model: ContextualAI/archangel_sft-kto_pythia2-8b
+#   ref_model: ContextualAI/archangel_sft_pythia2-8b
+#   tokenizer: ContextualAI/archangel_sft-kto_pythia2-8b
+#   chat_template: tulu
+#   batch_size: 4
+#   trust_remote_code: False
+#   dpo: True
+# ContextualAI/archangel_sft-dpo_pythia6-9b:
+#   model: ContextualAI/archangel_sft-dpo_pythia6-9b
+#   ref_model: ContextualAI/archangel_sft_pythia6-9b
+#   tokenizer: ContextualAI/archangel_sft-dpo_pythia6-9b
+#   chat_template: tulu
+#   batch_size: 4
+#   trust_remote_code: False
+#   dpo: True
+# ContextualAI/archangel_sft-kto_pythia6-9b:
+#   model: ContextualAI/archangel_sft-kto_pythia6-9b
+#   ref_model: ContextualAI/archangel_sft_pythia6-9b
+#   tokenizer: ContextualAI/archangel_sft-kto_pythia6-9b
+#   chat_template: tulu
+#   batch_size: 4
+#   trust_remote_code: False
+#   dpo: True
+# ContextualAI/archangel_sft-dpo_pythia12-0b:
+#   model: ContextualAI/archangel_sft-dpo_pythia12-0b
+#   ref_model: ContextualAI/archangel_sft_pythia12-0b
+#   tokenizer: ContextualAI/archangel_sft-dpo_pythia12-0b
+#   chat_template: tulu
+#   batch_size: 4
+#   num_gpus: 2
+#   trust_remote_code: False
+#   dpo: True
+# ContextualAI/archangel_sft-kto_pythia12-0b:
+#   model: ContextualAI/archangel_sft-kto_pythia12-0b
+#   ref_model: ContextualAI/archangel_sft_pythia12-0b
+#   tokenizer: ContextualAI/archangel_sft-kto_pythia12-0b
+#   chat_template: tulu
+#   batch_size: 4
+#   num_gpus: 2
+#   trust_remote_code: False
+#   dpo: True
+# 0-hero/Matter-0.1-7B-DPO-preview:
+#   model: 0-hero/Matter-0.1-7B-DPO-preview
+#   ref_model: 0-hero/Matter-0.1-7B
+#   tokenizer: 0-hero/Matter-0.1-7B-DPO-preview
+#   chat_template: # none for tokenizer
+#   batch_size: 4
+#   trust_remote_code: False
+#   dpo: True
+# 0-hero/Matter-0.1-7B-boost-DPO-preview:
+#   model: 0-hero/Matter-0.1-7B-boost-DPO-preview
+#   ref_model: 0-hero/Matter-0.1-7B-boost
+#   tokenizer: 0-hero/Matter-0.1-7B-boost-DPO-preview
+#   chat_template: # none for tokenizer
+#   batch_size: 4
+#   trust_remote_code: False
+#   dpo: True

--- a/scripts/configs/eval_configs.yaml
+++ b/scripts/configs/eval_configs.yaml
@@ -34,13 +34,13 @@ weqweasdas/hh_rlhf_rm_open_llama_3b:
   batch_size: 64
   trust_remote_code: False
   dpo: False
-# llm-blender/PairRM-hf:
-#   model: 'llm-blender/PairRM-hf'
-#   tokenizer: 'llm-blender/PairRM-hf'
-#   chat_template: 'tulu'
-#   batch_size: 64
-#   trust_remote_code: False
-#   dpo: False
+llm-blender/PairRM-hf:
+  model: 'llm-blender/PairRM-hf'
+  tokenizer: 'llm-blender/PairRM-hf'
+  chat_template: 'tulu'
+  batch_size: 64
+  trust_remote_code: False
+  dpo: False
 berkeley-nest/Starling-RM-7B-alpha:
   model: 'berkeley-nest/Starling-RM-7B-alpha'
   tokenizer: 'meta-llama/Llama-2-7b-chat-hf'
@@ -48,20 +48,20 @@ berkeley-nest/Starling-RM-7B-alpha:
   batch_size: 16
   trust_remote_code: False
   dpo: False
-# stanfordnlp/SteamSHP-flan-t5-xl:
-#   model: 'stanfordnlp/SteamSHP-flan-t5-xl'
-#   tokenizer: 'stanfordnlp/SteamSHP-flan-t5-xl'
-#   chat_template: 'tulu'
-#   batch_size: 32
-#   trust_remote_code: False
-#   dpo: False
-# stanfordnlp/SteamSHP-flan-t5-large:
-#   model: 'stanfordnlp/SteamSHP-flan-t5-large'
-#   tokenizer: 'stanfordnlp/SteamSHP-flan-t5-large'
-#   chat_template: 'tulu'
-#   batch_size: 32
-#   trust_remote_code: False
-#   dpo: False
+stanfordnlp/SteamSHP-flan-t5-xl:
+  model: 'stanfordnlp/SteamSHP-flan-t5-xl'
+  tokenizer: 'stanfordnlp/SteamSHP-flan-t5-xl'
+  chat_template: 'tulu'
+  batch_size: 32
+  trust_remote_code: False
+  dpo: False
+stanfordnlp/SteamSHP-flan-t5-large:
+  model: 'stanfordnlp/SteamSHP-flan-t5-large'
+  tokenizer: 'stanfordnlp/SteamSHP-flan-t5-large'
+  chat_template: 'tulu'
+  batch_size: 32
+  trust_remote_code: False
+  dpo: False
 PKU-Alignment/beaver-7b-v1.0-reward:
   model: 'PKU-Alignment/beaver-7b-v1.0-reward'
   tokenizer: 'PKU-Alignment/beaver-7b-v1.0-reward'
@@ -83,321 +83,321 @@ IDEA-CCNL/Ziya-LLaMA-7B-Reward:
   batch_size: 16
   trust_remote_code: True
   dpo: False
-# Nexusflow/Starling-RM-34B:
-#   model: 'Nexusflow/Starling-RM-34B'
-#   tokenizer: '01-ai/Yi-34B-Chat'
-#   chat_template: 'Yi-34b-chat'
-#   num_gpus: 2
-#   batch_size: 2
-#   trust_remote_code: False
-#   dpo: False
-# stabilityai/stablelm-zephyr-3b:
-#   ref_model: stabilityai/stablelm-3b-4e1t
-#   tokenizer: stabilityai/stablelm-zephyr-3b
-#   chat_template:
-#   batch_size: 12
-#   trust_remote_code: False
-#   dpo: True
-# stabilityai/stablelm-2-zephyr-1_6b:
-#   ref_model: stabilityai/stablelm-2-1_6b
-#   tokenizer: stabilityai/stablelm-2-zephyr-1_6b
-#   chat_template:
-#   batch_size: 6
-#   trust_remote_code: True
-#   dpo: True
-# HuggingFaceH4/zephyr-7b-beta:
-#   ref_model: HuggingFaceH4/mistral-7b-sft-beta
-#   tokenizer: HuggingFaceH4/zephyr-7b-beta
-#   chat_template:
-#   batch_size: 4
-#   trust_remote_code: False
-#   dpo: True
-# HuggingFaceH4/zephyr-7b-alpha:
-#   ref_model: HuggingFaceH4/mistral-7b-sft-alpha
-#   tokenizer: HuggingFaceH4/zephyr-7b-alpha
-#   chat_template:
-#   batch_size: 4
-#   trust_remote_code: False
-#   dpo: True
-# Qwen/Qwen1.5-0.5B-Chat:
-#   ref_model: Qwen/Qwen1.5-0.5B
-#   tokenizer: Qwen/Qwen1.5-0.5B-Chat
-#   chat_template:
-#   batch_size: 6
-#   trust_remote_code: False
-#   dpo: True
-# Qwen/Qwen1.5-1.8B-Chat:
-#   ref_model: Qwen/Qwen1.5-1.8B
-#   tokenizer: Qwen/Qwen1.5-1.8B-Chat
-#   chat_template:
-#   batch_size: 3
-#   trust_remote_code: False
-#   dpo: True
-# Qwen/Qwen1.5-4B-Chat:
-#   ref_model: Qwen/Qwen1.5-4B
-#   tokenizer: Qwen/Qwen1.5-4B-Chat
-#   chat_template:
-#   batch_size: 2
-#   trust_remote_code: False
-#   dpo: True
-# Qwen/Qwen1.5-7B-Chat:
-#   ref_model: Qwen/Qwen1.5-7B
-#   tokenizer: Qwen/Qwen1.5-7B-Chat
-#   chat_template:
-#   batch_size: 2
-#   trust_remote_code: False
-#   dpo: True
-# Qwen/Qwen1.5-14B-Chat:
-#   ref_model: Qwen/Qwen1.5-14B
-#   tokenizer: Qwen/Qwen1.5-14B-Chat
-#   chat_template:
-#   batch_size: 2
-#   num_gpus: 2
-#   trust_remote_code: False
-#   dpo: True
-# Qwen/Qwen1.5-72B-Chat:
-#   ref_model: Qwen/Qwen1.5-72B
-#   tokenizer: Qwen/Qwen1.5-72B-Chat
-#   chat_template:
-#   batch_size: 1
-#   num_gpus: 4
-#   trust_remote_code: False
-#   dpo: True
-# mistralai/Mixtral-8x7B-Instruct-v0.1:
-#   ref_model: mistralai/Mixtral-8x7B-v0.1
-#   tokenizer: mistralai/Mixtral-8x7B-Instruct-v0.1
-#   chat_template:
-#   batch_size: 1
-#   num_gpus: 4
-#   trust_remote_code: False
-#   dpo: True
-# NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO:
-#   ref_model: NousResearch/Nous-Hermes-2-Mixtral-8x7B-SFT
-#   tokenizer: NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO
-#   chat_template:
-#   batch_size: 1
-#   num_gpus: 4
-#   trust_remote_code: True
-#   dpo: True
-# NousResearch/Nous-Hermes-2-Mistral-7B-DPO:
-#   ref_model: teknium/OpenHermes-2.5-Mistral-7B
-#   tokenizer: NousResearch/Nous-Hermes-2-Mistral-7B-DPO
-#   chat_template:
-#   batch_size: 4
-#   trust_remote_code: False
-#   dpo: True
-# HuggingFaceH4/zephyr-7b-gemma-v0.1:
-#   ref_model: HuggingFaceH4/zephyr-7b-gemma-sft-v0.1
-#   tokenizer: HuggingFaceH4/zephyr-7b-gemma-v0.1
-#   chat_template:
-#   batch_size: 2
-#   trust_remote_code: False
-#   dpo: True
-# allenai/tulu-2-dpo-70b:
-#   ref_model: allenai/tulu-2-70b
-#   tokenizer: allenai/tulu-2-dpo-70b
-#   chat_template: tulu
-#   num_gpus: 4
-#   batch_size: 2
-#   trust_remote_code: False
-#   dpo: True
-# allenai/tulu-2-dpo-13b:
-#   ref_model: allenai/tulu-2-13b
-#   tokenizer: allenai/tulu-2-dpo-13b
-#   chat_template: tulu
-#   num_gpus: 2
-#   batch_size: 2
-#   trust_remote_code: False
-#   dpo: True
-# allenai/tulu-2-dpo-7b:
-#   ref_model: allenai/tulu-2-7b
-#   tokenizer: allenai/tulu-2-dpo-7b
-#   chat_template: tulu
-#   batch_size: 2
-#   trust_remote_code: False
-#   dpo: True
-# allenai/OLMo-7B-Instruct:
-#   ref_model: allenai/OLMo-7B-SFT
-#   tokenizer: allenai/OLMo-7B-Instruct
-#   chat_template:
-#   batch_size: 2
-#   trust_remote_code: True
-#   dpo: True
-# # Added March 21st 2024
-# weqweasdas/RM-Gemma-2B:
-#   model: weqweasdas/RM-Gemma-2B
-#   tokenizer: weqweasdas/RM-Gemma-2B
-#   chat_template: # empty for tokenizer
-#   batch_size: 16
-#   trust_remote_code: False
-#   dpo: False
-# weqweasdas/RM-Gemma-7B:
-#   model: weqweasdas/RM-Gemma-7B
-#   tokenizer: weqweasdas/RM-Gemma-7B
-#   chat_template: # empty for tokenizer
-#   batch_size: 16
-#   trust_remote_code: False
-#   dpo: False
-# weqweasdas/RM-Gemma-7B-4096:
-#   model: weqweasdas/RM-Gemma-7B-4096
-#   tokenizer: weqweasdas/RM-Gemma-7B-4096
-#   chat_template: # empty for tokenizer
-#   batch_size: 16
-#   trust_remote_code: False
-#   dpo: False
-# Ray2333/reward-model-Mistral-7B-instruct-Unified-Feedback:
-#   model: Ray2333/reward-model-Mistral-7B-instruct-Unified-Feedback
-#   tokenizer: Ray2333/reward-model-Mistral-7B-instruct-Unified-Feedback
-#   chat_template: # empty for tokenizer
-#   batch_size: 16
-#   trust_remote_code: False
-#   dpo: False
-# hendrydong/Mistral-RM-for-RAFT-GSHF-v0:
-#   model: hendrydong/Mistral-RM-for-RAFT-GSHF-v0
-#   tokenizer: hendrydong/Mistral-RM-for-RAFT-GSHF-v0
-#   chat_template: # empty for tokenizer
-#   batch_size: 16
-#   trust_remote_code: False
-#   dpo: False
-# weqweasdas/RM-Mistral-7B:
-#   model: weqweasdas/RM-Mistral-7B
-#   tokenizer: weqweasdas/RM-Mistral-7B
-#   chat_template: # empty for tokenizer
-#   batch_size: 16
-#   trust_remote_code: False
-#   dpo: False
-# # Added March 25th 2024 KTO / Archangel models follow
-# ContextualAI/archangel_sft-kto_llama7b:
-#   model: ContextualAI/archangel_sft-kto_llama7b
-#   ref_model: ContextualAI/archangel_sft_llama7b
-#   tokenizer: ContextualAI/archangel_sft-kto_llama7b
-#   chat_template: tulu
-#   batch_size: 4
-#   trust_remote_code: False
-#   dpo: True
-# ContextualAI/archangel_sft-dpo_llama7b:
-#   model: ContextualAI/archangel_sft-dpo_llama7b
-#   ref_model: ContextualAI/archangel_sft_llama7b
-#   tokenizer: ContextualAI/archangel_sft-dpo_llama7b
-#   chat_template: tulu
-#   batch_size: 4
-#   trust_remote_code: False
-#   dpo: True
-# ContextualAI/archangel_sft-kto_llama13b:
-#   model: ContextualAI/archangel_sft-kto_llama13b
-#   ref_model: ContextualAI/archangel_sft_llama13b
-#   tokenizer: ContextualAI/archangel_sft-kto_llama13b
-#   chat_template: tulu
-#   batch_size: 2
-#   num_gpus: 2
-#   trust_remote_code: False
-#   dpo: True
-# ContextualAI/archangel_sft-dpo_llama13b:
-#   model: ContextualAI/archangel_sft-dpo_llama13b
-#   ref_model: ContextualAI/archangel_sft_llama13b
-#   tokenizer: ContextualAI/archangel_sft-dpo_llama13b
-#   chat_template: tulu
-#   batch_size: 2
-#   num_gpus: 2
-#   trust_remote_code: False
-#   dpo: True
-# ContextualAI/archangel_sft-kto_llama30b:
-#   model: ContextualAI/archangel_sft-kto_llama30b
-#   ref_model: ContextualAI/archangel_sft_llama30b
-#   tokenizer: ContextualAI/archangel_sft-kto_llama30b
-#   chat_template: tulu
-#   batch_size: 1
-#   num_gpus: 4
-#   trust_remote_code: False
-#   dpo: True
-# ContextualAI/archangel_sft-dpo_llama30b:
-#   model: ContextualAI/archangel_sft-dpo_llama30b
-#   ref_model: ContextualAI/archangel_sft_llama30b
-#   tokenizer: ContextualAI/archangel_sft-dpo_llama30b
-#   chat_template: tulu
-#   batch_size: 1
-#   num_gpus: 4
-#   trust_remote_code: False
-#   dpo: True
-# ContextualAI/archangel_sft-dpo_pythia1-4b:
-#   model: ContextualAI/archangel_sft-dpo_pythia1-4b
-#   ref_model: ContextualAI/archangel_sft_pythia1-4b
-#   tokenizer: ContextualAI/archangel_sft-dpo_pythia1-4b
-#   chat_template: tulu
-#   batch_size: 6
-#   trust_remote_code: False
-#   dpo: True
-# ContextualAI/archangel_sft-kto_pythia1-4b:
-#   model: ContextualAI/archangel_sft-kto_pythia1-4b
-#   ref_model: ContextualAI/archangel_sft_pythia1-4b
-#   tokenizer: ContextualAI/archangel_sft-kto_pythia1-4b
-#   chat_template: tulu
-#   batch_size: 6
-#   trust_remote_code: False
-#   dpo: True
-# ContextualAI/archangel_sft-dpo_pythia2-8b:
-#   model: ContextualAI/archangel_sft-dpo_pythia2-8b
-#   ref_model: ContextualAI/archangel_sft_pythia2-8b
-#   tokenizer: ContextualAI/archangel_sft-dpo_pythia2-8b
-#   chat_template: tulu
-#   batch_size: 4
-#   trust_remote_code: False
-#   dpo: True
-# ContextualAI/archangel_sft-kto_pythia2-8b:
-#   model: ContextualAI/archangel_sft-kto_pythia2-8b
-#   ref_model: ContextualAI/archangel_sft_pythia2-8b
-#   tokenizer: ContextualAI/archangel_sft-kto_pythia2-8b
-#   chat_template: tulu
-#   batch_size: 4
-#   trust_remote_code: False
-#   dpo: True
-# ContextualAI/archangel_sft-dpo_pythia6-9b:
-#   model: ContextualAI/archangel_sft-dpo_pythia6-9b
-#   ref_model: ContextualAI/archangel_sft_pythia6-9b
-#   tokenizer: ContextualAI/archangel_sft-dpo_pythia6-9b
-#   chat_template: tulu
-#   batch_size: 4
-#   trust_remote_code: False
-#   dpo: True
-# ContextualAI/archangel_sft-kto_pythia6-9b:
-#   model: ContextualAI/archangel_sft-kto_pythia6-9b
-#   ref_model: ContextualAI/archangel_sft_pythia6-9b
-#   tokenizer: ContextualAI/archangel_sft-kto_pythia6-9b
-#   chat_template: tulu
-#   batch_size: 4
-#   trust_remote_code: False
-#   dpo: True
-# ContextualAI/archangel_sft-dpo_pythia12-0b:
-#   model: ContextualAI/archangel_sft-dpo_pythia12-0b
-#   ref_model: ContextualAI/archangel_sft_pythia12-0b
-#   tokenizer: ContextualAI/archangel_sft-dpo_pythia12-0b
-#   chat_template: tulu
-#   batch_size: 4
-#   num_gpus: 2
-#   trust_remote_code: False
-#   dpo: True
-# ContextualAI/archangel_sft-kto_pythia12-0b:
-#   model: ContextualAI/archangel_sft-kto_pythia12-0b
-#   ref_model: ContextualAI/archangel_sft_pythia12-0b
-#   tokenizer: ContextualAI/archangel_sft-kto_pythia12-0b
-#   chat_template: tulu
-#   batch_size: 4
-#   num_gpus: 2
-#   trust_remote_code: False
-#   dpo: True
-# 0-hero/Matter-0.1-7B-DPO-preview:
-#   model: 0-hero/Matter-0.1-7B-DPO-preview
-#   ref_model: 0-hero/Matter-0.1-7B
-#   tokenizer: 0-hero/Matter-0.1-7B-DPO-preview
-#   chat_template: # none for tokenizer
-#   batch_size: 4
-#   trust_remote_code: False
-#   dpo: True
-# 0-hero/Matter-0.1-7B-boost-DPO-preview:
-#   model: 0-hero/Matter-0.1-7B-boost-DPO-preview
-#   ref_model: 0-hero/Matter-0.1-7B-boost
-#   tokenizer: 0-hero/Matter-0.1-7B-boost-DPO-preview
-#   chat_template: # none for tokenizer
-#   batch_size: 4
-#   trust_remote_code: False
-#   dpo: True
+Nexusflow/Starling-RM-34B:
+  model: 'Nexusflow/Starling-RM-34B'
+  tokenizer: '01-ai/Yi-34B-Chat'
+  chat_template: 'Yi-34b-chat'
+  num_gpus: 2
+  batch_size: 2
+  trust_remote_code: False
+  dpo: False
+stabilityai/stablelm-zephyr-3b:
+  ref_model: stabilityai/stablelm-3b-4e1t
+  tokenizer: stabilityai/stablelm-zephyr-3b
+  chat_template:
+  batch_size: 12
+  trust_remote_code: False
+  dpo: True
+stabilityai/stablelm-2-zephyr-1_6b:
+  ref_model: stabilityai/stablelm-2-1_6b
+  tokenizer: stabilityai/stablelm-2-zephyr-1_6b
+  chat_template:
+  batch_size: 6
+  trust_remote_code: True
+  dpo: True
+HuggingFaceH4/zephyr-7b-beta:
+  ref_model: HuggingFaceH4/mistral-7b-sft-beta
+  tokenizer: HuggingFaceH4/zephyr-7b-beta
+  chat_template:
+  batch_size: 4
+  trust_remote_code: False
+  dpo: True
+HuggingFaceH4/zephyr-7b-alpha:
+  ref_model: HuggingFaceH4/mistral-7b-sft-alpha
+  tokenizer: HuggingFaceH4/zephyr-7b-alpha
+  chat_template:
+  batch_size: 4
+  trust_remote_code: False
+  dpo: True
+Qwen/Qwen1.5-0.5B-Chat:
+  ref_model: Qwen/Qwen1.5-0.5B
+  tokenizer: Qwen/Qwen1.5-0.5B-Chat
+  chat_template:
+  batch_size: 6
+  trust_remote_code: False
+  dpo: True
+Qwen/Qwen1.5-1.8B-Chat:
+  ref_model: Qwen/Qwen1.5-1.8B
+  tokenizer: Qwen/Qwen1.5-1.8B-Chat
+  chat_template:
+  batch_size: 3
+  trust_remote_code: False
+  dpo: True
+Qwen/Qwen1.5-4B-Chat:
+  ref_model: Qwen/Qwen1.5-4B
+  tokenizer: Qwen/Qwen1.5-4B-Chat
+  chat_template:
+  batch_size: 2
+  trust_remote_code: False
+  dpo: True
+Qwen/Qwen1.5-7B-Chat:
+  ref_model: Qwen/Qwen1.5-7B
+  tokenizer: Qwen/Qwen1.5-7B-Chat
+  chat_template:
+  batch_size: 2
+  trust_remote_code: False
+  dpo: True
+Qwen/Qwen1.5-14B-Chat:
+  ref_model: Qwen/Qwen1.5-14B
+  tokenizer: Qwen/Qwen1.5-14B-Chat
+  chat_template:
+  batch_size: 2
+  num_gpus: 2
+  trust_remote_code: False
+  dpo: True
+Qwen/Qwen1.5-72B-Chat:
+  ref_model: Qwen/Qwen1.5-72B
+  tokenizer: Qwen/Qwen1.5-72B-Chat
+  chat_template:
+  batch_size: 1
+  num_gpus: 4
+  trust_remote_code: False
+  dpo: True
+mistralai/Mixtral-8x7B-Instruct-v0.1:
+  ref_model: mistralai/Mixtral-8x7B-v0.1
+  tokenizer: mistralai/Mixtral-8x7B-Instruct-v0.1
+  chat_template:
+  batch_size: 1
+  num_gpus: 4
+  trust_remote_code: False
+  dpo: True
+NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO:
+  ref_model: NousResearch/Nous-Hermes-2-Mixtral-8x7B-SFT
+  tokenizer: NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO
+  chat_template:
+  batch_size: 1
+  num_gpus: 4
+  trust_remote_code: True
+  dpo: True
+NousResearch/Nous-Hermes-2-Mistral-7B-DPO:
+  ref_model: teknium/OpenHermes-2.5-Mistral-7B
+  tokenizer: NousResearch/Nous-Hermes-2-Mistral-7B-DPO
+  chat_template:
+  batch_size: 4
+  trust_remote_code: False
+  dpo: True
+HuggingFaceH4/zephyr-7b-gemma-v0.1:
+  ref_model: HuggingFaceH4/zephyr-7b-gemma-sft-v0.1
+  tokenizer: HuggingFaceH4/zephyr-7b-gemma-v0.1
+  chat_template:
+  batch_size: 2
+  trust_remote_code: False
+  dpo: True
+allenai/tulu-2-dpo-70b:
+  ref_model: allenai/tulu-2-70b
+  tokenizer: allenai/tulu-2-dpo-70b
+  chat_template: tulu
+  num_gpus: 4
+  batch_size: 2
+  trust_remote_code: False
+  dpo: True
+allenai/tulu-2-dpo-13b:
+  ref_model: allenai/tulu-2-13b
+  tokenizer: allenai/tulu-2-dpo-13b
+  chat_template: tulu
+  num_gpus: 2
+  batch_size: 2
+  trust_remote_code: False
+  dpo: True
+allenai/tulu-2-dpo-7b:
+  ref_model: allenai/tulu-2-7b
+  tokenizer: allenai/tulu-2-dpo-7b
+  chat_template: tulu
+  batch_size: 2
+  trust_remote_code: False
+  dpo: True
+allenai/OLMo-7B-Instruct:
+  ref_model: allenai/OLMo-7B-SFT
+  tokenizer: allenai/OLMo-7B-Instruct
+  chat_template:
+  batch_size: 2
+  trust_remote_code: True
+  dpo: True
+# Added March 21st 2024
+weqweasdas/RM-Gemma-2B:
+  model: weqweasdas/RM-Gemma-2B
+  tokenizer: weqweasdas/RM-Gemma-2B
+  chat_template: # empty for tokenizer
+  batch_size: 16
+  trust_remote_code: False
+  dpo: False
+weqweasdas/RM-Gemma-7B:
+  model: weqweasdas/RM-Gemma-7B
+  tokenizer: weqweasdas/RM-Gemma-7B
+  chat_template: # empty for tokenizer
+  batch_size: 16
+  trust_remote_code: False
+  dpo: False
+weqweasdas/RM-Gemma-7B-4096:
+  model: weqweasdas/RM-Gemma-7B-4096
+  tokenizer: weqweasdas/RM-Gemma-7B-4096
+  chat_template: # empty for tokenizer
+  batch_size: 16
+  trust_remote_code: False
+  dpo: False
+Ray2333/reward-model-Mistral-7B-instruct-Unified-Feedback:
+  model: Ray2333/reward-model-Mistral-7B-instruct-Unified-Feedback
+  tokenizer: Ray2333/reward-model-Mistral-7B-instruct-Unified-Feedback
+  chat_template: # empty for tokenizer
+  batch_size: 16
+  trust_remote_code: False
+  dpo: False
+hendrydong/Mistral-RM-for-RAFT-GSHF-v0:
+  model: hendrydong/Mistral-RM-for-RAFT-GSHF-v0
+  tokenizer: hendrydong/Mistral-RM-for-RAFT-GSHF-v0
+  chat_template: # empty for tokenizer
+  batch_size: 16
+  trust_remote_code: False
+  dpo: False
+weqweasdas/RM-Mistral-7B:
+  model: weqweasdas/RM-Mistral-7B
+  tokenizer: weqweasdas/RM-Mistral-7B
+  chat_template: # empty for tokenizer
+  batch_size: 16
+  trust_remote_code: False
+  dpo: False
+# Added March 25th 2024 KTO / Archangel models follow
+ContextualAI/archangel_sft-kto_llama7b:
+  model: ContextualAI/archangel_sft-kto_llama7b
+  ref_model: ContextualAI/archangel_sft_llama7b
+  tokenizer: ContextualAI/archangel_sft-kto_llama7b
+  chat_template: tulu
+  batch_size: 4
+  trust_remote_code: False
+  dpo: True
+ContextualAI/archangel_sft-dpo_llama7b:
+  model: ContextualAI/archangel_sft-dpo_llama7b
+  ref_model: ContextualAI/archangel_sft_llama7b
+  tokenizer: ContextualAI/archangel_sft-dpo_llama7b
+  chat_template: tulu
+  batch_size: 4
+  trust_remote_code: False
+  dpo: True
+ContextualAI/archangel_sft-kto_llama13b:
+  model: ContextualAI/archangel_sft-kto_llama13b
+  ref_model: ContextualAI/archangel_sft_llama13b
+  tokenizer: ContextualAI/archangel_sft-kto_llama13b
+  chat_template: tulu
+  batch_size: 2
+  num_gpus: 2
+  trust_remote_code: False
+  dpo: True
+ContextualAI/archangel_sft-dpo_llama13b:
+  model: ContextualAI/archangel_sft-dpo_llama13b
+  ref_model: ContextualAI/archangel_sft_llama13b
+  tokenizer: ContextualAI/archangel_sft-dpo_llama13b
+  chat_template: tulu
+  batch_size: 2
+  num_gpus: 2
+  trust_remote_code: False
+  dpo: True
+ContextualAI/archangel_sft-kto_llama30b:
+  model: ContextualAI/archangel_sft-kto_llama30b
+  ref_model: ContextualAI/archangel_sft_llama30b
+  tokenizer: ContextualAI/archangel_sft-kto_llama30b
+  chat_template: tulu
+  batch_size: 1
+  num_gpus: 4
+  trust_remote_code: False
+  dpo: True
+ContextualAI/archangel_sft-dpo_llama30b:
+  model: ContextualAI/archangel_sft-dpo_llama30b
+  ref_model: ContextualAI/archangel_sft_llama30b
+  tokenizer: ContextualAI/archangel_sft-dpo_llama30b
+  chat_template: tulu
+  batch_size: 1
+  num_gpus: 4
+  trust_remote_code: False
+  dpo: True
+ContextualAI/archangel_sft-dpo_pythia1-4b:
+  model: ContextualAI/archangel_sft-dpo_pythia1-4b
+  ref_model: ContextualAI/archangel_sft_pythia1-4b
+  tokenizer: ContextualAI/archangel_sft-dpo_pythia1-4b
+  chat_template: tulu
+  batch_size: 6
+  trust_remote_code: False
+  dpo: True
+ContextualAI/archangel_sft-kto_pythia1-4b:
+  model: ContextualAI/archangel_sft-kto_pythia1-4b
+  ref_model: ContextualAI/archangel_sft_pythia1-4b
+  tokenizer: ContextualAI/archangel_sft-kto_pythia1-4b
+  chat_template: tulu
+  batch_size: 6
+  trust_remote_code: False
+  dpo: True
+ContextualAI/archangel_sft-dpo_pythia2-8b:
+  model: ContextualAI/archangel_sft-dpo_pythia2-8b
+  ref_model: ContextualAI/archangel_sft_pythia2-8b
+  tokenizer: ContextualAI/archangel_sft-dpo_pythia2-8b
+  chat_template: tulu
+  batch_size: 4
+  trust_remote_code: False
+  dpo: True
+ContextualAI/archangel_sft-kto_pythia2-8b:
+  model: ContextualAI/archangel_sft-kto_pythia2-8b
+  ref_model: ContextualAI/archangel_sft_pythia2-8b
+  tokenizer: ContextualAI/archangel_sft-kto_pythia2-8b
+  chat_template: tulu
+  batch_size: 4
+  trust_remote_code: False
+  dpo: True
+ContextualAI/archangel_sft-dpo_pythia6-9b:
+  model: ContextualAI/archangel_sft-dpo_pythia6-9b
+  ref_model: ContextualAI/archangel_sft_pythia6-9b
+  tokenizer: ContextualAI/archangel_sft-dpo_pythia6-9b
+  chat_template: tulu
+  batch_size: 4
+  trust_remote_code: False
+  dpo: True
+ContextualAI/archangel_sft-kto_pythia6-9b:
+  model: ContextualAI/archangel_sft-kto_pythia6-9b
+  ref_model: ContextualAI/archangel_sft_pythia6-9b
+  tokenizer: ContextualAI/archangel_sft-kto_pythia6-9b
+  chat_template: tulu
+  batch_size: 4
+  trust_remote_code: False
+  dpo: True
+ContextualAI/archangel_sft-dpo_pythia12-0b:
+  model: ContextualAI/archangel_sft-dpo_pythia12-0b
+  ref_model: ContextualAI/archangel_sft_pythia12-0b
+  tokenizer: ContextualAI/archangel_sft-dpo_pythia12-0b
+  chat_template: tulu
+  batch_size: 4
+  num_gpus: 2
+  trust_remote_code: False
+  dpo: True
+ContextualAI/archangel_sft-kto_pythia12-0b:
+  model: ContextualAI/archangel_sft-kto_pythia12-0b
+  ref_model: ContextualAI/archangel_sft_pythia12-0b
+  tokenizer: ContextualAI/archangel_sft-kto_pythia12-0b
+  chat_template: tulu
+  batch_size: 4
+  num_gpus: 2
+  trust_remote_code: False
+  dpo: True
+0-hero/Matter-0.1-7B-DPO-preview:
+  model: 0-hero/Matter-0.1-7B-DPO-preview
+  ref_model: 0-hero/Matter-0.1-7B
+  tokenizer: 0-hero/Matter-0.1-7B-DPO-preview
+  chat_template: # none for tokenizer
+  batch_size: 4
+  trust_remote_code: False
+  dpo: True
+0-hero/Matter-0.1-7B-boost-DPO-preview:
+  model: 0-hero/Matter-0.1-7B-boost-DPO-preview
+  ref_model: 0-hero/Matter-0.1-7B-boost
+  tokenizer: 0-hero/Matter-0.1-7B-boost-DPO-preview
+  chat_template: # none for tokenizer
+  batch_size: 4
+  trust_remote_code: False
+  dpo: True

--- a/scripts/run_bon.py
+++ b/scripts/run_bon.py
@@ -28,7 +28,12 @@ from fastchat.conversation import get_conv_template
 from tqdm import tqdm
 from transformers import AutoTokenizer, pipeline
 
-from rewardbench import REWARD_MODEL_CONFIG, load_bon_dataset, save_to_hub
+from rewardbench import (
+    REWARD_MODEL_CONFIG,
+    check_tokenizer_chat_template,
+    load_bon_dataset,
+    save_to_hub,
+)
 
 # get token from HF_TOKEN env variable, but if it doesn't exist pass none
 HF_TOKEN = os.getenv("HF_TOKEN", None)
@@ -172,7 +177,7 @@ def main():
         reward_pipe.tokenizer.pad_token_id = reward_pipe.tokenizer.eos_token_id
 
     # if using fastchat template (no template in tokenizer), make the RM tokenizer output an EOS token
-    if not hasattr(reward_pipe.tokenizer, "chat_template"):
+    if not check_tokenizer_chat_template(tokenizer):
         reward_pipe.tokenizer.add_eos_token = True
 
     ############################

--- a/scripts/run_bon.py
+++ b/scripts/run_bon.py
@@ -171,6 +171,10 @@ def main():
         reward_pipe.model.config.pad_token_id = reward_pipe.tokenizer.eos_token_id
         reward_pipe.tokenizer.pad_token_id = reward_pipe.tokenizer.eos_token_id
 
+    # if using fastchat template (no template in tokenizer), make the RM tokenizer output an EOS token
+    if not hasattr(reward_pipe.tokenizer, "chat_template"):
+        reward_pipe.tokenizer.add_eos_token = True
+
     ############################
     # Run inference [1/2]" built in transformers
     ############################

--- a/scripts/run_rm.py
+++ b/scripts/run_rm.py
@@ -176,7 +176,7 @@ def main():
     # if using fastchat template (no template in tokenizer), make the RM tokenizer output an EOS token
     if not hasattr(reward_pipe.tokenizer, "chat_template"):
         reward_pipe.tokenizer.add_eos_token = True
-        
+
     ############################
     # Run inference [1/2]" built in transformers
     ############################

--- a/scripts/run_rm.py
+++ b/scripts/run_rm.py
@@ -173,6 +173,10 @@ def main():
         reward_pipe.model.config.pad_token_id = reward_pipe.tokenizer.eos_token_id
         reward_pipe.tokenizer.pad_token_id = reward_pipe.tokenizer.eos_token_id
 
+    # if using fastchat template (no template in tokenizer), make the RM tokenizer output an EOS token
+    if not hasattr(reward_pipe.tokenizer, "chat_template"):
+        reward_pipe.tokenizer.add_eos_token = True
+        
     ############################
     # Run inference [1/2]" built in transformers
     ############################

--- a/scripts/run_rm.py
+++ b/scripts/run_rm.py
@@ -26,7 +26,12 @@ from fastchat.conversation import get_conv_template
 from tqdm import tqdm
 from transformers import AutoTokenizer, pipeline
 
-from rewardbench import REWARD_MODEL_CONFIG, load_eval_dataset, save_to_hub
+from rewardbench import (
+    REWARD_MODEL_CONFIG,
+    check_tokenizer_chat_template,
+    load_eval_dataset,
+    save_to_hub,
+)
 
 # get token from HF_TOKEN env variable, but if it doesn't exist pass none
 HF_TOKEN = os.getenv("HF_TOKEN", None)
@@ -174,7 +179,7 @@ def main():
         reward_pipe.tokenizer.pad_token_id = reward_pipe.tokenizer.eos_token_id
 
     # if using fastchat template (no template in tokenizer), make the RM tokenizer output an EOS token
-    if not hasattr(reward_pipe.tokenizer, "chat_template"):
+    if not check_tokenizer_chat_template(tokenizer):
         reward_pipe.tokenizer.add_eos_token = True
 
     ############################
@@ -280,7 +285,9 @@ def main():
     results_grouped = {}
     results_grouped["model"] = args.model
     results_grouped["model_type"] = model_type
-    results_grouped["chat_template"] = args.chat_template if not hasattr(tokenizer, "chat_template") else "tokenizer"
+    results_grouped["chat_template"] = (
+        args.chat_template if not check_tokenizer_chat_template(tokenizer) else "tokenizer"
+    )
 
     # print per subset and log into results_grouped file
     present_subsets = np.unique(subsets)

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -28,7 +28,7 @@ argparser.add_argument(
     "--eval_on_pref_sets", action="store_true", default=False, help="Evaluate on preference sets rather than core set"
 )
 argparser.add_argument("--eval_on_bon", action="store_true", default=False, help="Evaluate on BON preference sets")
-argparser.add_argument("--image", type=str, default="nathanl/rewardbench_v3", help="Beaker image to use")
+argparser.add_argument("--image", type=str, default="nathanl/rewardbench_v4", help="Beaker image to use")
 argparser.add_argument("--cluster", type=str, default="ai2/allennlp-cirrascale", help="Beaker cluster to use")
 argparser.add_argument("--upload_to_hub", action="store_false", default=True, help="Upload to results to HF hub")
 argparser.add_argument("--model", type=str, default=None, help="Specific model to evaluate if not sweep")

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -28,7 +28,7 @@ argparser.add_argument(
     "--eval_on_pref_sets", action="store_true", default=False, help="Evaluate on preference sets rather than core set"
 )
 argparser.add_argument("--eval_on_bon", action="store_true", default=False, help="Evaluate on BON preference sets")
-argparser.add_argument("--image", type=str, default="nathanl/rewardbench_v2", help="Beaker image to use")
+argparser.add_argument("--image", type=str, default="nathanl/rewardbench_v3", help="Beaker image to use")
 argparser.add_argument("--cluster", type=str, default="ai2/allennlp-cirrascale", help="Beaker cluster to use")
 argparser.add_argument("--upload_to_hub", action="store_false", default=True, help="Upload to results to HF hub")
 argparser.add_argument("--model", type=str, default=None, help="Specific model to evaluate if not sweep")


### PR DESCRIPTION
Closes #90 
Effected models to re-run (prev score --> new score):
* openbmb/UltraRM-13b (69.53 --> 68.18)
* OpenAssistant/oasst-rm-2.1-pythia-1.4b-epoch-2.5 (69.6 --> 69.49)
* OpenAssistant/oasst-rm-2-pythia-6.9b-epoch-1 (62.05 --> 62.23)
* OpenAssistant/reward-model-deberta-v3-large-v2 (57.49 --> 54.29)
* weqweasdas/hh_rlhf_rm_open_llama_3b (54.92 --> 48.85)
* berkeley-nest/Starling-RM-7B-alpha (71.42 --> 71.43)
* PKU-Alignment/beaver-7b-v1.0-reward (47.62 --> 45.44)
* PKU-Alignment/beaver-7b-v1.0-cost (58.25 --> 59.83)
* IDEA-CCNL/Ziya-LLaMA-7B-Reward (63.43 --> 62.94)

These had a stronger effect on Tulu models, interestingly.