### PR TITLE
Add `pad_token_id` from tokenizer to model config.

### DIFF
--- a/scripts/run_bon.py
+++ b/scripts/run_bon.py
@@ -175,6 +175,9 @@ def main():
     if reward_pipe.tokenizer.pad_token_id is None:
         reward_pipe.model.config.pad_token_id = reward_pipe.tokenizer.eos_token_id
         reward_pipe.tokenizer.pad_token_id = reward_pipe.tokenizer.eos_token_id
+    # For models whose config did not contains `pad_token_id`
+    if reward_pipe.model.config.pad_token_id is None:
+        reward_pipe.model.config.pad_token_id = reward_pipe.tokenizer.pad_token_id
 
     # if using fastchat template (no template in tokenizer), make the RM tokenizer output an EOS token
     if not check_tokenizer_chat_template(tokenizer):

--- a/scripts/run_rm.py
+++ b/scripts/run_rm.py
@@ -183,6 +183,8 @@ def main():
     if reward_pipe.tokenizer.pad_token_id is None:
         reward_pipe.model.config.pad_token_id = reward_pipe.tokenizer.eos_token_id
         reward_pipe.tokenizer.pad_token_id = reward_pipe.tokenizer.eos_token_id
+    elif reward_pipe.model.config.pad_token_id is None:
+        reward_pipe.model.config.pad_token_id = reward_pipe.tokenizer.pad_token_id
 
     # if using fastchat template (no template in tokenizer), make the RM tokenizer output an EOS token
     if not check_tokenizer_chat_template(tokenizer):

--- a/scripts/run_rm.py
+++ b/scripts/run_rm.py
@@ -183,7 +183,8 @@ def main():
     if reward_pipe.tokenizer.pad_token_id is None:
         reward_pipe.model.config.pad_token_id = reward_pipe.tokenizer.eos_token_id
         reward_pipe.tokenizer.pad_token_id = reward_pipe.tokenizer.eos_token_id
-    elif reward_pipe.model.config.pad_token_id is None:
+    # For models whose config did not contains `pad_token_id`
+    if reward_pipe.model.config.pad_token_id is None:
         reward_pipe.model.config.pad_token_id = reward_pipe.tokenizer.pad_token_id
 
     # if using fastchat template (no template in tokenizer), make the RM tokenizer output an EOS token


### PR DESCRIPTION
Resolves #115 

Add `pad_token_id` to model config for models whose config did not contains `pad_token_id`. ex. TinyLlama