### PR TITLE
Update pip Installation Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The two primary scripts to generate results (more in `scripts/`):
 RewardBench let's you quickly evaluate any reward model on any preference set. 
 To install for quick usage, install with pip as:
 ```
-pip install reward bench
+pip install rewardbench
 ```
 Then, run a following:
 ```


### PR DESCRIPTION
The original pip installation command in README is

`pip install reward bench`

which added a whitespace that leads to the installation of `reward` and `bench` packages.

This PR fixes it to 

`pip install rewardbench`

which installs the correct version from https://pypi.org/project/rewardbench/