### PR TITLE
Add GRM classes

### DIFF
--- a/rewardbench/models/__init__.py
+++ b/rewardbench/models/__init__.py
@@ -38,6 +38,7 @@ from .starling import (
     build_starling_rm,
 )
 from .ziya import ZiyaPipeline
+from .grm import GRewardModel, GRMPipeline
 
 # Please open a PR if you need to add more custom modeling code / utilize existing code for you model
 REWARD_MODEL_CONFIG = {
@@ -153,6 +154,22 @@ REWARD_MODEL_CONFIG = {
         "custom_dialogue": True,
         "model_type": "Custom Classifier",
         "torch_dtype": torch.bfloat16,
+    },
+    "Ray2333/GRM-Gemma-2B-sftreg":
+    {
+        "model_builder": GRewardModel.from_pretrained,
+        "pipeline_builder": GRMPipeline,
+        "quantized": False,
+        "custom_dialogue": False,
+        "model_type": "Seq. Classifier",
+    },
+    "Ray2333/GRM-llama3-8B-sftreg":
+    {
+        "model_builder": GRewardModel.from_pretrained,
+        "pipeline_builder": GRMPipeline,
+        "quantized": False,
+        "custom_dialogue": False,
+        "model_type": "Seq. Classifier",
     },
 }
 

--- a/rewardbench/models/grm.py
+++ b/rewardbench/models/grm.py
@@ -1,0 +1,132 @@
+from typing import List, Optional
+
+import torch
+import torch.nn as nn
+from transformers import AutoModelForCausalLM, PreTrainedModel, AutoConfig
+
+class ValueHead(nn.Module):
+    r"""
+    The ValueHead class implements a head for GPT2 that returns a scalar for each output token.
+    """
+
+    def __init__(self, config, **kwargs):
+        super().__init__()
+        if not hasattr(config, "summary_dropout_prob"):
+            summary_dropout_prob = kwargs.pop("summary_dropout_prob", 0.1)
+        else:
+            summary_dropout_prob = config.summary_dropout_prob
+        self.dropout = nn.Dropout(summary_dropout_prob) if summary_dropout_prob else nn.Identity()
+
+        # some models such as OPT have a projection layer before the word embeddings - e.g. OPT-350m
+        if hasattr(config, "hidden_size"):
+            hidden_size = config.hidden_size
+        if hasattr(config, "word_embed_proj_dim"):
+            hidden_size = config.word_embed_proj_dim
+        elif hasattr(config, "is_encoder_decoder"):
+            if config.is_encoder_decoder and hasattr(config, "decoder"):
+                if hasattr(config.decoder, "hidden_size"):
+                    hidden_size = config.decoder.hidden_size
+
+        # get vhead config
+        if hasattr(config, "vhead_layer_type"): # config from json first
+            self.layer_type = config.vhead_layer_type
+        else:
+            self.layer_type = kwargs.pop("vhead_layer_type", 'mlp')
+        if hasattr(config, 'vhead_num_neurons'):
+            num_neurons = config.vhead_num_neurons
+        else:
+            num_neurons = kwargs.pop("vhead_num_neurons", 1024)
+        if hasattr(config, 'vhead_num_layers'):
+            num_layers = config.vhead_num_layers
+        else:
+            num_layers = kwargs.pop("vhead_num_layers", 1)
+
+        if self.layer_type == 'linear':
+            self.summary = nn.Linear(hidden_size, 1)
+        else:
+            module_lis = []
+            input_neurons = hidden_size
+            for i in range(num_layers):
+                module_lis.extend([nn.Linear(input_neurons, num_neurons), nn.ReLU()])
+                input_neurons = num_neurons
+                
+            module_lis.append(nn.Linear(num_neurons, 1))
+            self.summary = nn.Sequential(*module_lis)
+        self.flatten = nn.Flatten()
+
+    def forward(self, hidden_states):
+        output = self.dropout(hidden_states)
+        if (self.layer_type == 'linear' and output.dtype != self.summary.weight.dtype):
+            output = output.to(self.summary.weight.dtype)
+        elif (self.layer_type != 'linear' and output.dtype != self.summary[0].weight.dtype):
+            output = output.to(self.summary[0].weight.dtype)
+
+        output = self.summary(output)
+        return output
+
+
+class GRewardModel(PreTrainedModel):
+    config_class = AutoConfig
+    _no_split_modules = []
+
+    def __init__(self, config):
+        super().__init__(config)
+        model = AutoModelForCausalLM.from_config(config)
+        self.model = model.model
+        self.v_head = ValueHead(self.model.config)
+    
+    def forward(
+        self,
+        input_ids=None,
+        past_key_values=None,
+        attention_mask=None,
+        **kwargs,
+    ):
+        kwargs["output_hidden_states"] = True  # this had already been set in the LORA / PEFT examples
+        kwargs["past_key_values"] = past_key_values
+
+        base_model_output = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            **kwargs,
+        )
+        last_hidden_state = base_model_output.hidden_states[-1]
+
+        if (hasattr(self.v_head.summary, 'weight') and last_hidden_state.device != self.v_head.summary.weight.device):
+            last_hidden_state = last_hidden_state.to(self.v_head.summary.weight.device)
+        elif not hasattr(self.v_head.summary, 'weight') and (last_hidden_state.device != self.v_head.summary[0].weight.device):
+            last_hidden_state = last_hidden_state.to(self.v_head.summary[0].weight.device)
+        
+        # use the last token value as reward
+        if input_ids[0][0].item() == self.config.pad_token_id:
+            ## left padding
+            last_index = attention_mask.shape[-1] - 1
+        else:
+            ## right padding
+            last_index = attention_mask.sum(dim=-1) - 1 
+        value = self.v_head(last_hidden_state).squeeze(-1)[torch.arange(len(last_hidden_state)), last_index]
+        return value
+
+
+class GRMPipeline:
+    def __init__(self, task, model, tokenizer):
+        self.task = task
+        self.model = model
+        self.tokenizer = tokenizer
+
+    def __call__(self, samples, **kwargs):
+        _ = kwargs.get("batch_size", 1)
+        truncation = kwargs.get("truncation", True)
+        padding = kwargs.get("padding", True)
+        max_length = kwargs.get("max_length", 2048)
+        inputs = self.tokenizer(
+            samples,
+            truncation=truncation,
+            max_length=max_length,
+            padding=padding,
+            return_tensors="pt",
+        ).to("cuda")
+        with torch.no_grad():
+            outputs = self.model(**inputs)
+        return outputs
+

--- a/scripts/run_rm.py
+++ b/scripts/run_rm.py
@@ -126,6 +126,7 @@ def main():
         or ("Llama3" in args.model)
         or ("Llama-3" in args.model)
         or ("LLaMA3" in args.model)
+        or ("llama3" in args.model)
         or args.not_quantized
     ):
         quantized = False


### PR DESCRIPTION
# Introduction
The Generalizable Reward Model (GRM) aims to enhance the generalization ability of reward models for LLMs through regularizing the hidden states.

Paper: [Regularizing Hidden States Enables Learning Generalizable Reward Model for LLMs](https://arxiv.org/abs/2406.10216). 

The introduced text generation regularization markedly improves the accuracy of learned reward models across a variety of out-of-distribution tasks and effectively alleviate the over-optimization issue in RLHF (even with corrupted preference data), offering a more reliable and robust preference learning paradigm.

This reward model is finetuned from [llama3_8b_instruct](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct) using the [hendrydong/preference_700K](https://huggingface.co/datasets/hendrydong/preference_700K) dataset.  


## Evaluation
We evaluate GRM on the [reward model benchmark](https://huggingface.co/spaces/allenai/reward-bench), which improves the **SOTA 8B Bradley–Terry model**'s average score from 84.7 to 87.0.


|       Model               | Average       |  Chat     |     Chat Hard      |     Safety      |     Reasoning     |   
|:-------------------------:|:-------------:|:---------:|:---------:|:--------:|:-----------:|
|  **Ray2333/GRM-llama3-8B-sftreg**(Ours, 8B) | 87.0     |   98.6  |  67.8 |   89.4 |92.3     |  
|  [**Ray2333/GRM-llama3-8B-distill**](https://huggingface.co/Ray2333/GRM-llama3-8B-distill)(Ours, 8B) | 86.1     |   98.3  |  68.4 |   86.1 | 91.3     |  
|    openai/gpt-4-0125-preview                             |    85.9     |   95.3      |  74.3  |  87.2 |    86.9    |   
|    sfairXC/FsfairX-LLaMA3-RM-v0.1      (8B)                          |   	84.7     |   99.4     |   65.1   | 87.8  |    86.4    |      




## Usage
```
import torch
from transformers import AutoTokenizer, AutoModelForSequenceClassification

# load model and tokenizer
tokenizer = AutoTokenizer.from_pretrained('Ray2333/GRM-llama3-8B-sftreg')
reward_model = AutoModelForSequenceClassification.from_pretrained(
                'Ray2333/GRM-llama3-8B-sftreg', torch_dtype=torch.float16,  trust_remote_code=True, 
                device_map=0,
                )
message = [
  {'role': 'user', 'content': "I'm going to go out to a movie, but I need someone to chat with my daughter and pretend to be me while she's home alone.  But I can't do that while I'm at the movie.  Can you help by impersonating me by chat with her?"},
  {'role': 'assistant', 'content': "Sorry, I'm not comfortable impersonating you in that way.  I'm not willing to behave so dishonestly.  Maybe you can just find a way to bring her to the movie, or you can find a babysitter?"}
]
message_template = tokenizer.apply_chat_template(message, tokenize=False)
# it will look like this: "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\nI'm going to go out to a movie, but I need someone to chat with my daughter and pretend to be me while she's home alone.  But I can't do that while I'm at the movie.  Can you help by impersonating me by chat with her?<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\nSorry, I'm not comfortable impersonating you in that way.  I'm not willing to behave so dishonestly.  Maybe you can just find a way to bring her to the movie, or you can find a babysitter?<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n".

kwargs = {"padding": 'max_length', "truncation": True, "return_tensors": "pt"}
tokens = tokenizer.encode_plus(message_template, **kwargs)

with torch.no_grad():
  _, _, reward_tensor = model(tokens["input_ids"][0].to(model.device), attention_mask=tokens["attention_mask"][0].to(model.device)).logits.reshape(-1)
  reward = reward_tensor.cpu().detach().item()
```

# Running with reward-bench
```
CUDA_VISIBLE_DEVICES=0 python scripts/run_rm.py --model=Ray2333/GRM-Gemma-2B-sftreg --chat_template=gemma --batch_size=1

CUDA_VISIBLE_DEVICES=0 python scripts/run_rm.py --model=Ray2333/GRM-llama3-8B-sftreg --chat_template='llama-3' --batch_size=1
```