### PR TITLE
fix padding for GRM class

### DIFF
--- a/rewardbench/models/grm.py
+++ b/rewardbench/models/grm.py
@@ -95,7 +95,7 @@ class GRewardModel(PreTrainedModel):
             last_hidden_state = last_hidden_state.to(self.v_head.summary[0].weight.device)
 
         # use the last token value as reward
-        if input_ids[0][0].item() == self.config.pad_token_id:
+        if torch.any(attention_mask[:, 0] == 0):
             # left padding
             last_index = attention_mask.shape[-1] - 1
         else:


### PR DESCRIPTION
I noticed that the evaluation results for Ray2333/GRM-Gemma-2B-sftreg differ significantly from my local results due to the padding side issue (I use a batch size of 1, so I didn't encounter this problem). 

This pull request addresses the padding issue by checking the conditions of left and right paddings to correctly project the score from the last token of each prompt-response pair.