### PR TITLE
add_con-j_support_code

### DIFF
--- a/rewardbench/generative.py
+++ b/rewardbench/generative.py
@@ -235,6 +235,7 @@ CON_J_PROMPT = """作为一个评价专家，给定一个问题和它的两个�
 回答1：{output_1}
 回答2：{output_2}"""
 
+
 # format with prompt_template.format(question=question, answer_a=answer_a, answer_b=answer_b)
 def format_judge_answers(question, answer_a, answer_b, multi_turn=False, model_modifier=None):
     kwargs = {}
@@ -294,6 +295,7 @@ def format_judge_answers(question, answer_a, answer_b, multi_turn=False, model_m
 
     return system_prompt, user_prompt
 
+
 def con_j_evaluate(gen):
     def normalize_digit(digit):
         digit_map = {'１': '1', '２': '2'}
@@ -340,7 +342,7 @@ def con_j_evaluate(gen):
                     json_content = json_content_candidate
                     break
             except json.JSONDecodeError:
-                continue 
+                continue
     if json_content is None:
         try:
             json_content_candidate = json.loads(gen)
@@ -357,7 +359,7 @@ def con_j_evaluate(gen):
                     json_content = json_content_candidate
                     break
             except json.JSONDecodeError:
-                continue 
+                continue
     if json_content is None or '更好的回答' not in json_content:
         json_content = parse_evaluation(gen)
     if isinstance(json_content, dict) and '更好的回答' in json_content:
@@ -367,6 +369,7 @@ def con_j_evaluate(gen):
         elif value == '2':
             return 'B'
     return 'None'
+
 
 def process_judgement(judgment, model_modifier):
     if model_modifier == "prometheus":

--- a/scripts/run_generative.py
+++ b/scripts/run_generative.py
@@ -25,6 +25,7 @@ import logging
 import os
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
+import sys
 
 import numpy as np
 from fastchat.conversation import get_conv_template
@@ -144,6 +145,8 @@ def main():
     # use different prompt for prometheus/gemini models
     if "prometheus" in args.model:
         model_modifier = "prometheus"
+    elif "Con-J" in args.model:
+        model_modifier = "Con-J"
     elif "OffsetBias" in args.model:
         model_modifier = "offsetbias"
     elif "gemini" in args.model:

--- a/scripts/run_generative.py
+++ b/scripts/run_generative.py
@@ -25,7 +25,6 @@ import logging
 import os
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
-import sys
 
 import numpy as np
 from fastchat.conversation import get_conv_template


### PR DESCRIPTION
Add code support for a new generative model named Con-J-Qwen2-7B, we would like to contribute it to reward-bench.

We can test Con-J-Qwen2-7B by 
```
python scripts/run_generative.py --model="ZiyiYe/Con-J-Qwen2-7B"
```

This is our local test results:
{'Chat': 0.9189944134078212, 'Chat Hard': 0.7982456140350878, 'Safety': 0.8797297297297297, 'Reasoning': 0.881871692039068}