### PR TITLE
Tiny dtype fix

### DIFF
--- a/rewardbench/models/armorm.py
+++ b/rewardbench/models/armorm.py
@@ -22,7 +22,7 @@ class ArmoRMPipeline:
             padding=padding,
             # return_special_tokens_mask=True,
             return_tensors="pt",
-        ).to(self.model.device)
+        ).to("cuda")
 
         with torch.no_grad():
             outputs = self.model(**inputs)

--- a/rewardbench/models/armorm.py
+++ b/rewardbench/models/armorm.py
@@ -22,7 +22,7 @@ class ArmoRMPipeline:
             padding=padding,
             # return_special_tokens_mask=True,
             return_tensors="pt",
-        ).to("cuda")
+        ).to(self.model.device)
 
         with torch.no_grad():
             outputs = self.model(**inputs)

--- a/rewardbench/rewardbench.py
+++ b/rewardbench/rewardbench.py
@@ -511,7 +511,7 @@ def rewardbench(args: Args):
             if isinstance(rewards[0], dict):
                 scores = [result["score"] for result in rewards]
             else:
-                scores = rewards.cpu().numpy().tolist()
+                scores = rewards.cpu().float().numpy().tolist()
             results.extend(scores)
 
     ############################


### PR DESCRIPTION
When a model gives a bfloat16, .numpy() can be unhappy. This happens for e.g. Skywork.