### PR TITLE
Request to Evaluate Lenovo-Reward-Gemma-2-27B-v1.0 on RewardBench

### DIFF
--- a/rewardbench/models/__init__.py
+++ b/rewardbench/models/__init__.py
@@ -41,7 +41,7 @@ from .starling import (
     build_starling_rm,
 )
 from .ziya import ZiyaPipeline
-
+from .lenovo import LenovoPipeline
 # Please open a PR if you need to add more custom modeling code / utilize existing code for you model
 REWARD_MODEL_CONFIG = {
     "default": {
@@ -50,6 +50,14 @@ REWARD_MODEL_CONFIG = {
         "quantized": True,
         "custom_dialogue": False,
         "model_type": "Seq. Classifier",
+    },
+    "lenovo/Lenovo-Reward-Gemma-2-27B-v1.0": {
+        "model_builder": AutoModelForSequenceClassification.from_pretrained,
+        "pipeline_builder": LenovoPipeline,
+        "quantized": False,
+        "custom_dialogue": False,
+        "model_type": "Seq. Classifier",
+        "torch_dtype": torch.bfloat16,
     },
     "berkeley-nest/Starling-RM-7B-alpha": {
         "model_builder": build_starling_rm,

--- a/rewardbench/models/lenovo.py
+++ b/rewardbench/models/lenovo.py
@@ -1,0 +1,55 @@
+import torch
+
+class LenovoPipeline:
+    def __init__(self, task, model, tokenizer):
+        self.task = task
+        self.model = model.eval()
+        self.tokenizer = tokenizer
+
+    def __call__(self, samples, return_inputs=False, **kwargs):
+        _ = kwargs.get("batch_size", 1)
+        truncation = kwargs.get("truncation", True)
+        padding = kwargs.get("padding", True)
+        max_length = kwargs.get("max_length", 2048)
+        inputs = self.tokenizer(
+            samples,
+            truncation=truncation,
+            max_length=max_length,
+            padding=padding,
+            return_tensors="pt",
+        ).to("cuda")
+
+        # if tokenizer.bos_token exists, check if there is a double bos token to start the inputs
+        # if so, we'll remove the first one and pass in the inputs (somewhat hacky solution)
+        # a full refactor can be done to use tokenizer.apply_chat_template(chat, tokenize=True)
+        # though, so many RM implementations are non standard, so this is a quick fix rather than ecosystem wide
+        if self.tokenizer.bos_token:
+            bos_token_id = self.tokenizer.bos_token_id
+            input_ids = inputs["input_ids"]
+            attention_mask = inputs["attention_mask"]
+
+            # Ensure input_ids is 2D
+            if input_ids.dim() == 1:
+                input_ids = input_ids.unsqueeze(0)
+                attention_mask = attention_mask.unsqueeze(0)
+
+            # Find the start of each sequence (first non-pad token)
+            seq_starts = attention_mask.argmax(dim=1)
+
+            # Check for double BOS tokens
+            seq_second = torch.clamp(seq_starts + 1, max=input_ids.size(1) - 1)
+            double_bos_mask = (input_ids[torch.arange(input_ids.size(0)), seq_starts] == bos_token_id) & (
+                input_ids[torch.arange(input_ids.size(0)), seq_second] == bos_token_id
+            )
+
+            # Set attention mask to 0 for the first BOS token where double BOS is detected
+            if double_bos_mask.any():
+                inputs['attention_mask'] = inputs['attention_mask'][:,1:]
+                inputs['input_ids'] = inputs['input_ids'][:,1:]
+
+        with torch.no_grad():
+            outputs = self.model(**inputs)
+        if return_inputs:
+            return outputs.logits, inputs
+        else:
+            return outputs.logits


### PR DESCRIPTION
Hi RewardBench Team,

Could you please help us evaluate our model, https://huggingface.co/lenovo/Lenovo-Reward-Gemma-2-27B-v1.0, on RewardBench? You can use the following command for testing:

`python ./scripts/run_rm.py --model lenovo/Lenovo-Reward-Gemma-2-27B-v1.0 --batch_size 1 --do_not_save  --trust_remote_code --torch_dtype bfloat16 --attn_implementation flash_attention_2`

We expect the results to be as follows:

alpacaeval-easy: 99/100 (0.99)
alpacaeval-hard: 90/95 (0.9473684210526315)
alpacaeval-length: 90/95 (0.9473684210526315)
donotanswer: 105/136 (0.7720588235294118)
hep-cpp: 161/164 (0.9817073170731707)
hep-go: 160/164 (0.975609756097561)
hep-java: 163/164 (0.9939024390243902)
hep-js: 163/164 (0.9939024390243902)
hep-python: 160/164 (0.975609756097561)
hep-rust: 156/164 (0.9512195121951219)
llmbar-adver-GPTInst: 89/92 (0.967391304347826)
llmbar-adver-GPTOut: 41/47 (0.8723404255319149)
llmbar-adver-manual: 39/46 (0.8478260869565217)
llmbar-adver-neighbor: 121/134 (0.9029850746268657)
llmbar-natural: 95/100 (0.95)
math-prm: 446/447 (0.9977628635346756)
mt-bench-easy: 28/28 (1.0)
mt-bench-hard: 33/37 (0.8918918918918919)
mt-bench-med: 39/40 (0.975)
refusals-dangerous: 96/100 (0.96)
refusals-offensive: 99/100 (0.99)
xstest-should-refuse: 147/154 (0.9545454545454546)
xstest-should-respond: 239/250 (0.956)
{'Chat': 0.9664804469273743, 'Chat Hard': 0.9166666666666666, 'Safety': 0.927027027027027, 'Reasoning': 0.9882107000600208}
