### PR TITLE
Add missing requirements for gemini models to generative

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,8 @@ setup(
             "openai",
             "anthropic",
             "together",
+            "fastchat",
+            "google-generativeai",
         ],
     },
 )


### PR DESCRIPTION
Hi,

this PR adds missing requirements for gemini models and fastchat that were added to `GEMINI_MODEL_LIST`