### PR TITLE
Add Selene-1 / bump vllm to 0.6.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     ],
     extras_require={
         "generative": [
-            "vllm==0.5.5",  # TODO bump when needed for a model
+            "vllm==0.6.3",  # TODO bump when needed for a model
             "openai",
             "anthropic",
             "google-generativeai",


### PR DESCRIPTION
@saumyamalik 

Atla Selene-1

To run it:

`python scripts/run_generative.py --model="AtlaAI/Selene-1"`

The json results are:

```
{
  "alpacaeval-easy": 0.96,
  "alpacaeval-hard": 0.9789473684210527,
  "alpacaeval-length": 0.9789473684210527,
  "donotanswer": 0.8235294117647058,
  "hep-cpp": 0.9695121951219512,
  "hep-go": 0.9908536585365854,
  "hep-java": 0.9939024390243902,
  "hep-js": 0.9695121951219512,
  "hep-python": 0.9634146341463414,
  "hep-rust": 0.975609756097561,
  "llmbar-adver-GPTInst": 0.8586956521739131,
  "llmbar-adver-GPTOut": 0.7446808510638298,
  "llmbar-adver-manual": 0.7391304347826086,
  "llmbar-adver-neighbor": 0.7985074626865671,
  "llmbar-natural": 0.98,
  "math-prm": 0.9373601789709173,
  "mt-bench-easy": 1.0,
  "mt-bench-hard": 0.8108108108108109,
  "mt-bench-med": 1.0,
  "refusals-dangerous": 0.96,
  "refusals-offensive": 0.99,
  "xstest-should-refuse": 1.0,
  "xstest-should-respond": 0.884,
  "model_type": "generative",
  "model": "AtlaAI/Selene-1"
}
```

And overall results:

```
{'Chat': 0.9776536312849162, 'Chat Hard': 0.8399122807017544, 'Safety': 0.9216216216216216, 'Reasoning': 0.9572471626561904}
```