### PR TITLE
Fix UnboundLocalError for torch_dtype in rewardbench.py when using DPO models

### DIFF
--- a/rewardbench/rewardbench.py
+++ b/rewardbench/rewardbench.py
@@ -205,6 +205,7 @@ def main():
 
 # Secondary function structure needed to accomodate HuggingFace Args with CLI binding
 def rewardbench(args: Args):
+    torch_dtype = None
     if args.wandb_run is not None:
         wandb_run = wandb.Api().run(args.wandb_run)
         args.model = wandb_run.config["hf_name"]

--- a/scripts/run_generative.py
+++ b/scripts/run_generative.py
@@ -272,6 +272,7 @@ def main():
         ############################
 
         def format_judgements(batch, optional_chat_template=None):
+            prompt_ids = []  # Prevent crash if it's unused
             # TODO expand this to include fastchat chat templates if needed
             mult_turn = True if len(batch["text_chosen"]) > 2 else False
             prompt = batch["text_chosen"][0]["content"]


### PR DESCRIPTION
#### Issue:
When using a local or unlisted DPO model, the following error occurs:
`UnboundLocalError: cannot access local variable 'torch_dtype' where it is not associated with a value`

This is due to `torch_dtype` being initialized only within the non-DPO path (`if not is_dpo:`) but being referenced outside of that block.

#### Fix:
Initialize `torch_dtype = None` at the start of the `rewardbench(args)` function to ensure the variable exists regardless of model type.

#### Impact:
- Fixes RewardBench DPO evaluation with local or custom models
- Maintains compatibility with existing workflows