### PR TITLE
add support skywork-vl-reward code

### DIFF
--- a/rewardbench/models/__init__.py
+++ b/rewardbench/models/__init__.py
@@ -21,6 +21,7 @@ from transformers import (
     LlamaTokenizer,
     MixtralForCausalLM,
     T5ForConditionalGeneration,
+    Qwen2_5_VLForConditionalGeneration,
 )
 
 from .armorm import ArmoRMPipeline
@@ -42,6 +43,7 @@ from .starling import (
     StarlingPipeline,
     build_starling_rm,
 )
+from .skyvl import SkyVLPipeline
 from .ziya import ZiyaPipeline
 
 # Please open a PR if you need to add more custom modeling code / utilize existing code for you model
@@ -242,6 +244,14 @@ REWARD_MODEL_CONFIG = {
     "infly/INF-ORM-Llama3.1-70B": {
         "model_builder": INFORMForSequenceClassification.from_pretrained,
         "pipeline_builder": RewardBenchPipeline,
+        "quantized": False,
+        "custom_dialogue": False,
+        "model_type": "Seq. Classifier",
+        "torch_dtype": torch.bfloat16,
+    },
+    "Skywork/Skywork-VL-Reward-7B": {
+        "model_builder": Qwen2_5_VLForConditionalGeneration.from_pretrained,
+        "pipeline_builder": SkyVLPipeline,
         "quantized": False,
         "custom_dialogue": False,
         "model_type": "Seq. Classifier",

--- a/rewardbench/models/skyvl.py
+++ b/rewardbench/models/skyvl.py
@@ -1,0 +1,34 @@
+import torch
+from trl import AutoModelForCausalLMWithValueHead
+from transformers.utils import cached_file
+from safetensors import safe_open
+
+
+class SkyVLPipeline:
+    def __init__(self, task, model, tokenizer):
+        self.task = task
+        self.tokenizer = tokenizer
+        self.model = model
+        self.model = AutoModelForCausalLMWithValueHead.from_pretrained(
+            self.model
+        ).eval()
+        vhead_file = cached_file(
+            path_or_repo_id="Skywork/Skywork-VL-Reward-7B",
+            filename="value_head.safetensors",
+        )
+        with safe_open(vhead_file, framework="pt", device="cpu") as f:
+            vhead_params = {key: f.get_tensor(key) for key in f.keys()}
+        self.model.load_state_dict(vhead_params, strict=False)
+        self.model.requires_grad_(False)
+        self.model.eval()
+
+    def __call__(self, samples, **kwargs):
+        inputs = self.tokenizer(
+            samples, return_tensors="pt", padding=True, truncation=True
+        ).to("cuda")
+        with torch.no_grad():
+            values = self.model(**inputs, return_dict=True, use_cache=False)[-1]
+            score = values.gather(
+                dim=-1, index=(inputs["attention_mask"].sum(dim=-1, keepdim=True) - 1)
+            )
+            return score


### PR DESCRIPTION
env
transformers==4.51.3
trl==0.16.1
torch==2.6.0
torchvision==0.21.0
accelerate==1.6.0

We would like to add a multimodal reward model [Skywork/Skywork-VL-Reward-7B](https://huggingface.co/Skywork/Skywork-VL-Reward-7B) by:

python scripts/run_rm.py --model Skywork/Skywork-VL-Reward-7B --trust_remote_code --torch_dtype bfloat16 --batch_size 1

This is a multimodal reward model that shows promising and competitive performance on RewardBench.

This is our local test results:
{'Chat': 0.8994413407821229, 'Chat Hard': 0.875, 'Safety': 0.9108108108108108, 'Reasoning': 0.9175567468761936}

Thanks!