### PR TITLE
Add ratings and ties support for vllm models

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ pip install rewardbench
 ```
 python scripts/run_v2.py --model={yourmodel}
 ```
+
+Generative models can be run on RewardBench 2 either with a rankings-based prompt (comparing 4 responses in one go, the default) or a ratings-based prompt (scoring each response separately then recombining, run with `--score_w_ratings` flag). Note that our Ties subset, new in RewardBench 2, has up to 20+ completions to score per-prompt, so the code enforces that it runs in the ratings setting. For more information, see `scripts/run_generative_v2.py`. To add a custom prompt for your model, feel free to open a PR.
+```
+python scripts/run_generative_v2.py --model={yourmodel}
+```
+
 Or, to run RewardBench instead, run the following:
 ```
 rewardbench --model={yourmodel} --dataset={yourdataset} --batch_size=8

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The repository includes the following:
 * Common dataset formatting and tests for fair reward model inference.
 * Analysis and visualization tools.
 
-The two primary scripts to generate results (more in `scripts/`):
+The three primary scripts to generate results (more in `scripts/`):
 1. `scripts/run_rm.py`: Run evaluations for reward models.
 2. `scripts/run_dpo.py`: Run evaluations for direct preference optimization (DPO) models (and other models using implicit rewards, such as KTO).
 3. `scripts/run_v2.py`: Run evaluations for RewardBench 2, with special data handling for best-of-4 and Ties data.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The three primary scripts to generate results (more in `scripts/`):
 3. `scripts/run_v2.py`: Run evaluations for RewardBench 2, with special data handling for best-of-4 and Ties data.
 
 ## Quick Usage
-RewardBench let's you quickly evaluate any reward model on any preference set. 
+RewardBench lets you quickly evaluate any reward model on any preference set. 
 It also will detect if a instruction dataset is passed (by checking for not having `chosen`/`rejected`, and having `messages`) -- for these, just a model outputs are logged (not accuracy).
 
 To install for quick usage, install with pip as:

--- a/rewardbench/generative.py
+++ b/rewardbench/generative.py
@@ -126,7 +126,7 @@ prompt_v2_gemini = (
     "Avoid any position biases and ensure that the order in which the responses were presented does not influence your decision. "
     "Do not allow the length of the responses to influence your evaluation. Do not favor certain names of the assistants. "
     "Be as objective as possible. "
-    "Your output should only consist of '[[A]]' if assistant A is better, or '[[B]]' if assistant B is better. Omit any other output.\n"    # This is not in `prompt_v2`
+    "Your output should only consist of '[[A]]' if assistant A is better, or '[[B]]' if assistant B is better. Omit any other output.\n"  # This is not in `prompt_v2`
 )
 
 prompt_multi_v2 = (

--- a/rewardbench/utils.py
+++ b/rewardbench/utils.py
@@ -1076,10 +1076,11 @@ def process_single_model(dataset):
     # Tie-breaking term, optional, not much effect in practice
     # Normalised gap, then tanh to keep it in (‑1, 1)
     margin_scores = np.tanh(np.minimum(corr_incorrect_ref, corr_incorrect_ties) / diff_corr_margin - 1)
+    # if nan (divide by 0), set to 0
+    margin_scores = np.nan_to_num(margin_scores, nan=0.0)
     correctness_margin_score = float(np.mean(margin_scores))
 
-    # Compute the overall score — weighted 60% on accuracy (ref and tied), 40% on margins (normal and hard),
-    # and an additional 1% for tie-breaking
+    # Compute the overall score
     overall_score = (
         0.30 * tied_accuracy
         + 0.30 * ref_accuracy

--- a/scripts/submit_eval_jobs_v2.py
+++ b/scripts/submit_eval_jobs_v2.py
@@ -126,7 +126,7 @@ def main():
         f" --dataset {args.dataset}"
         f" --batch_size {model_config['batch_size']}"
     )
-    if model_config['tokenizer'] is not None:
+    if model_config["tokenizer"] is not None:
         config["tasks"][0]["arguments"][0] += f" --tokenizer {model_config['tokenizer']}"
     if model_config["chat_template"] is not None:
         config["tasks"][0]["arguments"][0] += f" --chat_template {model_config['chat_template']}"


### PR DESCRIPTION
Adds ratings (and therefore ties subset) support for vllm models. Note that with models I've tested, they do pretty poorly in this setting (probably not tuned to give ratings vs. pairwise rankings), but good to have for consistency with API models. This addresses issue #246 and PR #247  