### PR TITLE
Fix typo in rewardbench.py

### DIFF
--- a/rewardbench/rewardbench.py
+++ b/rewardbench/rewardbench.py
@@ -203,7 +203,7 @@ def main():
     rewardbench(*parser.parse_args_into_dataclasses())
 
 
-# Secondary function structure needed to accomodate HuggingFace Args with CLI binding
+# Secondary function structure needed to accommodate HuggingFace Args with CLI binding
 def rewardbench(args: Args):
     torch_dtype = None
     if args.wandb_run is not None:


### PR DESCRIPTION
## Summary
- Fix spelling typo in comment on line 206 of `rewardbench/rewardbench.py`: "accomodate" -> "accommodate"