### PR TITLE
fix(generative): use last-match for pairwise verdict extraction

### DIFF
--- a/rewardbench/generative.py
+++ b/rewardbench/generative.py
@@ -490,10 +490,9 @@ def process_judgement(judgment, model_modifier):
                 result = match.group(1).strip()
                 return result if result else "error"
     else:
-        if "[[A]]" in judgment:
-            return "A"
-        elif "[[B]]" in judgment:
-            return "B"
+        pairwise_matches = re.findall(r"\[\[([AB])\]\]", judgment.upper())
+        if pairwise_matches:
+            return pairwise_matches[-1]
         else:
             return "error"
 

--- a/rewardbench/generative_v2.py
+++ b/rewardbench/generative_v2.py
@@ -172,14 +172,9 @@ def format_judge_answers(question, answer_a, answer_b, answer_c, answer_d, multi
 
 
 def process_judgement(judgment, model_modifier):
-    if "[[A]]" in judgment:
-        return "A"
-    elif "[[B]]" in judgment:
-        return "B"
-    elif "[[C]]" in judgment:
-        return "C"
-    elif "[[D]]" in judgment:
-        return "D"
+    pairwise_matches = re.findall(r"\[\[([ABCD])\]\]", judgment.upper())
+    if pairwise_matches:
+        return pairwise_matches[-1]
     else:
         return "error"
 


### PR DESCRIPTION
## Summary

`process_judgement` in both `generative.py:493` and `generative_v2.py:175` used substring `in` checks (`if "[[A]]" in judgment` checked before `[[B]]`, `[[C]]`, `[[D]]`). This means the first verdict token found anywhere in the judge response wins, regardless of whether it appears in reasoning text or the final verdict.

## Fix

Replace the substring chain with `re.findall(r"\\[\\[([ABCD])\\]\\]", judgment.upper())[-1]` (last match). This binds the verdict to the judge's concluding token rather than to any token echoed in reasoning.

The comment at `generative_v2.py:187` notes this code was adapted from FastChat's `run_judge_pair`, which had the same issue and was fixed with the same approach (lm-sys/FastChat#3921).

## Verification

- `python3 -m py_compile`: compiles OK
- `black --check --line-length 119`: clean
- 2 files changed, 6 insertions, 12 deletions