### PR TITLE
Restore the vLLM sequence-length flag under its current name

### DIFF
--- a/scripts/run_generative.py
+++ b/scripts/run_generative.py
@@ -74,7 +74,7 @@ def get_args():
     )
     parser.add_argument("--num_gpus", type=int, default=1, help="number of gpus to use, for multi-node vllm")
     parser.add_argument("--vllm_gpu_util", type=float, default=0.9, help="gpu utilization for vllm")
-    # parser.add_argument("--vllm_max_seq_length", type=int, default=None, help="max sequence length for vllm")
+    parser.add_argument("--vllm_max_seq_length", type=int, default=None, help="max sequence length for vllm")
     parser.add_argument("--do_not_save", action="store_true", help="do not save results to hub (for debugging)")
     parser.add_argument(
         "--pref_sets", action="store_true", help="run on common preference sets instead of our custom eval set"
@@ -142,7 +142,7 @@ def main():
             trust_remote_code=args.trust_remote_code,
             tensor_parallel_size=args.num_gpus,
             gpu_memory_utilization=args.vllm_gpu_util,
-            # max_seq_length=args.vllm_max_seq_length,
+            max_model_len=args.vllm_max_seq_length,
         )
         tokenizer = AutoTokenizer.from_pretrained(args.model)
         if "Llama-3" in args.model or "llama3-8b" in args.model and "3.1" not in args.model:

--- a/scripts/run_generative_v2.py
+++ b/scripts/run_generative_v2.py
@@ -88,7 +88,7 @@ def get_args():
     )
     parser.add_argument("--num_gpus", type=int, default=1, help="number of gpus to use, for multi-node vllm")
     parser.add_argument("--vllm_gpu_util", type=float, default=0.9, help="gpu utilization for vllm")
-    # parser.add_argument("--vllm_max_seq_length", type=int, default=None, help="max sequence length for vllm")
+    parser.add_argument("--vllm_max_seq_length", type=int, default=None, help="max sequence length for vllm")
     parser.add_argument("--do_not_save", action="store_true", help="do not save results to hub (for debugging)")
     parser.add_argument(
         "--pref_sets", action="store_true", help="run on common preference sets instead of our custom eval set"
@@ -154,7 +154,7 @@ def main():
             trust_remote_code=args.trust_remote_code,
             tensor_parallel_size=args.num_gpus,
             gpu_memory_utilization=args.vllm_gpu_util,
-            # max_seq_length=args.vllm_max_seq_length,
+            max_model_len=args.vllm_max_seq_length,
         )
         tokenizer = AutoTokenizer.from_pretrained(args.model)
         if "Llama-3" in args.model or "llama3-8b" in args.model and "3.1" not in args.model:


### PR DESCRIPTION
`--vllm_max_seq_length` is commented out in both generative runners, together with the
`LLM()` keyword it fed:

| file | flag | keyword |
|---|---|---|
| `scripts/run_generative.py` | `:77` | `:145` |
| `scripts/run_generative_v2.py` | `:91` | `:157` |

**Uncommenting it alone does not work.** vLLM renamed that engine argument; `max_seq_length`
is no longer accepted, and `LLM()` would raise on it. This PR restores the flag and passes
it as `max_model_len`, which `EngineArgs` still exposes:

<pre>
$ python -c "import dataclasses; from vllm.engine.arg_utils import EngineArgs; print({f.name: f.default for f in dataclasses.fields(EngineArgs)}['max_model_len'])"
None
</pre>

Its default is `None`, so **behaviour is unchanged when the flag is not given** — the diff is
four lines and adds no new public flag.

### Why it matters

vLLM sizes its KV cache from the model's declared maximum context, so a judge whose config
declares a long context cannot start on a smaller card at all — it aborts before inference
rather than running slowly. Two of the five judges we tried declare 131,072 tokens, while
the longest four-way prompt in RewardBench 2 is 4,294 tokens. Without this flag those judges
are simply unrunnable on a 24 GB GPU; with it they run.

### Verification

`05a9005`, `vllm==0.13.0` as pinned in `pyproject.toml`, one RTX 4090 (24 GB). 240 passes
over five judges and 1,763 items each, on both `run_generative.py` and `run_generative_v2.py`
paths.

### Scope

Related to #274 but a different defect — that one is packaging, this one is the runner.

A second runner defect turned up alongside this one and is **not** in this PR: the `Atla`
branch at `run_generative_v2.py:627` calls `model.generate(prompt_token_ids=...)`, which
`vllm==0.13.0` does not accept, so `AtlaAI/Selene-1-Mini-Llama-3.1-8B` raises at inference.
That one needs a maintainer decision about whether the branch is still supported, so it is
filed separately rather than patched here.