### PR TITLE
Seed generative answer-position shuffling

### DIFF
--- a/rewardbench/random_utils.py
+++ b/rewardbench/random_utils.py
@@ -1,0 +1,11 @@
+"""Deterministic helpers for generative evaluation."""
+
+import numpy as np
+
+
+def generate_shuffle_positions(num_examples: int, seed: int) -> list[int]:
+    """Return one deterministic answer position for each evaluation example."""
+    if num_examples < 0:
+        raise ValueError("num_examples must be non-negative")
+
+    return np.random.default_rng(seed).integers(0, 4, size=num_examples).tolist()

--- a/scripts/run_generative_v2.py
+++ b/scripts/run_generative_v2.py
@@ -39,6 +39,7 @@ except ImportError:
 from vllm import LLM, SamplingParams
 
 from rewardbench import load_eval_dataset_multi, process_single_model, save_to_hub
+from rewardbench.random_utils import generate_shuffle_positions
 from rewardbench.generative_v2 import (
     ANTHROPIC_MODEL_LIST,
     API_MODEL_LIST,
@@ -98,6 +99,9 @@ def get_args():
     )
     parser.add_argument(
         "--num_threads", type=int, default=10, help="number of threads to use for parallel processing of examples"
+    )
+    parser.add_argument(
+        "--seed", type=int, default=0, help="seed for deterministic answer-position shuffling"
     )
     parser.add_argument(
         "--disable_beaker_save", action="store_true", help="disable saving the main results in a file for AI2 Beaker"
@@ -221,6 +225,11 @@ def main():
         ties_ids = ties_ids[:10]  # add ties ids to ties_ids
         nonties_ids = nonties_ids[:10]  # add ties ids to ids
 
+    # Materialize the answer position before threaded/API processing. This
+    # avoids relying on global RNG state, whose draw order can vary between
+    # runs when examples are processed in parallel.
+    dataset = dataset.add_column("shuffle_position", generate_shuffle_positions(len(dataset), args.seed))
+
     # output_path = f"final_results_{args.model}.jsonl"
     # if os.path.exists(output_path):
     #     os.remove(output_path)
@@ -248,7 +257,7 @@ def main():
                 answer_c = batch["texts_rejected"][1]
                 answer_d = batch["texts_rejected"][2]
 
-                shuffle_option = np.random.randint(0, 4)
+                shuffle_option = batch["shuffle_position"]
 
                 if shuffle_option == 0:
                     # Original order
@@ -403,7 +412,7 @@ def main():
             answer_c = batch["texts_rejected"][1]
             answer_d = batch["texts_rejected"][2]
 
-            shuffle_option = np.random.randint(0, 4)
+            shuffle_option = batch["shuffle_position"]
 
             # shuffle correct answer into random position, option 0 is original order
             if shuffle_option == 1:
@@ -481,7 +490,7 @@ def main():
                 answer_c = batch["texts_rejected"][1]
                 answer_d = batch["texts_rejected"][2]
 
-                shuffle_option = np.random.randint(0, 4)
+                shuffle_option = batch["shuffle_position"]
                 if shuffle_option == 0:
                     winner_text = "A"
                     loser_texts = ["B", "C", "D"]
@@ -631,6 +640,10 @@ def main():
                 print(f"Processing ties {i}/{len(ties_dataset_formatted)}")
             result = get_vllm_judgement(batch, is_ties=True)
             results_ties.append(result)
+
+    # The shuffle position is an inference-time implementation detail and is
+    # not part of the saved evaluation schema.
+    dataset = dataset.remove_columns("shuffle_position")
 
     ############################
     # Print & process results

--- a/tests/test_random_utils.py
+++ b/tests/test_random_utils.py
@@ -1,0 +1,32 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+# Import this dependency-free module directly so the focused test does not
+# require the optional model stack imported by rewardbench.__init__.
+module_path = Path(__file__).parents[1] / "rewardbench" / "random_utils.py"
+module_spec = importlib.util.spec_from_file_location("rewardbench_random_utils", module_path)
+assert module_spec is not None and module_spec.loader is not None
+random_utils = importlib.util.module_from_spec(module_spec)
+module_spec.loader.exec_module(random_utils)
+generate_shuffle_positions = random_utils.generate_shuffle_positions
+
+
+class RandomUtilsTest(unittest.TestCase):
+    def test_positions_are_reproducible_for_a_seed(self):
+        self.assertEqual(generate_shuffle_positions(32, 17), generate_shuffle_positions(32, 17))
+
+    def test_positions_are_in_the_four_valid_slots(self):
+        positions = generate_shuffle_positions(128, 17)
+
+        self.assertEqual(len(positions), 128)
+        self.assertTrue(all(position in range(4) for position in positions))
+
+    def test_negative_example_count_is_rejected(self):
+        with self.assertRaises(ValueError):
+            generate_shuffle_positions(-1, 17)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #272.

Generative RewardBench evaluation currently samples the correct answer position from global NumPy RNG state. This makes repeated runs non-reproducible and is especially fragile when API examples are processed concurrently. This change adds a `--seed` argument (default `0`), materializes one deterministic position per non-tie example before inference, and uses that position across the API and local four-way judge paths.

The inference-only position column is removed before the final output is concatenated and saved, preserving the existing output schema.

## Testing

- `python3 -m py_compile scripts/run_generative_v2.py rewardbench/random_utils.py tests/test_random_utils.py`
- `python3 -m unittest discover -s tests -p "test_random_utils.py"`
- Flake8 passes across `rewardbench`, `scripts`, `analysis`, and `tests` with `--max-line-length 119`.
- Black and isort pass on all three PR files after the formatting follow-up.
- Focused random-utils suite: 3 tests passed. Validation used the tool versions pinned in `uv.lock` in an isolated `uv` environment; no GPU/model inference was run.
